### PR TITLE
relay response message parsing and tests

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,2 +1,3 @@
 disabled_rules:
   - line_length
+  - identifier_name

--- a/Sources/NostrSDK/RelayMessage.swift
+++ b/Sources/NostrSDK/RelayMessage.swift
@@ -1,0 +1,49 @@
+//
+//  RelayMessage.swift
+//  
+//
+//  Created by Joel Klabo on 5/25/23.
+//
+
+import Foundation
+
+enum RelayResponse: Decodable {
+
+    enum MessageType: String, Codable {
+        case event = "EVENT"
+        case notice = "NOTICE"
+        case eose = "EOSE"
+    }
+
+    case notice(message: String)
+    case eose(subscriptionId: String)
+    case event(subscriptionId: String, event: NostrEvent)
+
+
+    init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        let responseType = try container.decode(MessageType.self)
+        switch responseType {
+        case .event:
+            let subscriptionId = try container.decode(String.self)
+            let event = try container.decode(NostrEvent.self)
+            self = .event(subscriptionId: subscriptionId, event: event)
+        case .notice:
+            let message = try container.decode(String.self)
+            self = .notice(message: message)
+        case .eose:
+            let subscriptionId = try container.decode(String.self)
+            self = .eose(subscriptionId: subscriptionId)
+        }
+    }
+
+    static func decode(data: Data) -> Self? {
+        let decoder = JSONDecoder()
+        do {
+            return try decoder.decode(Self.self, from: data)
+        } catch {
+            print("decode \(Self.Type.self) failed")
+        }
+        return nil
+    }
+}

--- a/Sources/NostrSDK/RelayMessage.swift
+++ b/Sources/NostrSDK/RelayMessage.swift
@@ -13,11 +13,13 @@ enum RelayResponse: Decodable {
         case event = "EVENT"
         case notice = "NOTICE"
         case eose = "EOSE"
+        case ok = "OK"
     }
 
     case notice(message: String)
     case eose(subscriptionId: String)
     case event(subscriptionId: String, event: NostrEvent)
+    case ok(eventId: String, success: Bool, message: String)
 
     init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
@@ -33,6 +35,11 @@ enum RelayResponse: Decodable {
         case .eose:
             let subscriptionId = try container.decode(String.self)
             self = .eose(subscriptionId: subscriptionId)
+        case .ok:
+            let eventId = try container.decode(String.self)
+            let success = try container.decode(Bool.self)
+            let message = try container.decode(String.self)
+            self = .ok(eventId: eventId, success: success, message: message)
         }
     }
 

--- a/Sources/NostrSDK/RelayMessage.swift
+++ b/Sources/NostrSDK/RelayMessage.swift
@@ -19,7 +19,6 @@ enum RelayResponse: Decodable {
     case eose(subscriptionId: String)
     case event(subscriptionId: String, event: NostrEvent)
 
-
     init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
         let responseType = try container.decode(MessageType.self)

--- a/Sources/NostrSDK/RelayMessage.swift
+++ b/Sources/NostrSDK/RelayMessage.swift
@@ -9,17 +9,23 @@ import Foundation
 
 enum RelayResponse: Decodable {
 
+    struct CountResponse: Codable {
+        let count: Int
+    }
+
     enum MessageType: String, Codable {
         case event = "EVENT"
         case notice = "NOTICE"
         case eose = "EOSE"
         case ok = "OK"
+        case count = "COUNT"
     }
 
     case notice(message: String)
     case eose(subscriptionId: String)
     case event(subscriptionId: String, event: NostrEvent)
     case ok(eventId: String, success: Bool, message: String)
+    case count(subscriptionId: String, count: Int)
 
     init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
@@ -40,6 +46,10 @@ enum RelayResponse: Decodable {
             let success = try container.decode(Bool.self)
             let message = try container.decode(String.self)
             self = .ok(eventId: eventId, success: success, message: message)
+        case .count:
+            let subscriptionId = try container.decode(String.self)
+            let countResponse = try container.decode(CountResponse.self)
+            self = .count(subscriptionId: subscriptionId, count: countResponse.count)
         }
     }
 

--- a/Sources/NostrSDK/RelayResponse.swift
+++ b/Sources/NostrSDK/RelayResponse.swift
@@ -19,6 +19,7 @@ enum RelayResponse: Decodable {
         case eose = "EOSE"
         case ok = "OK"
         case count = "COUNT"
+        case auth = "AUTH"
     }
 
     case notice(message: String)
@@ -26,6 +27,7 @@ enum RelayResponse: Decodable {
     case event(subscriptionId: String, event: NostrEvent)
     case ok(eventId: String, success: Bool, message: String)
     case count(subscriptionId: String, count: Int)
+    case auth(challenge: String)
 
     init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
@@ -50,6 +52,9 @@ enum RelayResponse: Decodable {
             let subscriptionId = try container.decode(String.self)
             let countResponse = try container.decode(CountResponse.self)
             self = .count(subscriptionId: subscriptionId, count: countResponse.count)
+        case .auth:
+            let challenge = try container.decode(String.self)
+            self = .auth(challenge: challenge)
         }
     }
 

--- a/Sources/NostrSDK/RelayResponse.swift
+++ b/Sources/NostrSDK/RelayResponse.swift
@@ -1,5 +1,5 @@
 //
-//  RelayMessage.swift
+//  RelayResponse.swift
 //  
 //
 //  Created by Joel Klabo on 5/25/23.

--- a/Tests/NostrSDKTests/Fixtures/auth_challenge.json
+++ b/Tests/NostrSDKTests/Fixtures/auth_challenge.json
@@ -1,0 +1,1 @@
+["AUTH", "some-challenge-string"]

--- a/Tests/NostrSDKTests/Fixtures/count_response.json
+++ b/Tests/NostrSDKTests/Fixtures/count_response.json
@@ -1,0 +1,1 @@
+["COUNT", "subscription-id", {"count": 238}]

--- a/Tests/NostrSDKTests/Fixtures/eose.json
+++ b/Tests/NostrSDKTests/Fixtures/eose.json
@@ -1,0 +1,1 @@
+["EOSE", "some-subscription-id"]

--- a/Tests/NostrSDKTests/Fixtures/event.json
+++ b/Tests/NostrSDKTests/Fixtures/event.json
@@ -1,0 +1,18 @@
+["EVENT", "some-subscription-id", {
+    "id": "fa5ed84fc8eeb959fd39ad8e48388cfc33075991ef8e50064cfcecfd918bb91b",
+    "pubkey": "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2",
+    "created_at": 1682080184,
+    "kind": 1,
+    "tags": [
+      [
+        "e",
+        "93930d65435d49db723499335473920795e7f13c45600dcfad922135cf44bd63"
+      ],
+      [
+        "p",
+        "f8e6c64342f1e052480630e27e1016dce35fc3a614e60434fef4aa2503328ca9"
+      ]
+    ],
+    "content": "I think it stays persistent on your profile, but interface setting doesn’t persist. Bug.  ",
+    "sig": "96e6667348b2b1fc5f6e73e68fb1605f571ad044077dda62a35c15eb8290f2c4559935db461f8466df3dcf39bc2e11984c5344f65aabee4520dd6653d74cdc09"
+  }]

--- a/Tests/NostrSDKTests/Fixtures/notice.json
+++ b/Tests/NostrSDKTests/Fixtures/notice.json
@@ -1,0 +1,1 @@
+["NOTICE", "there was an error"]

--- a/Tests/NostrSDKTests/Fixtures/ok_fail_reason.json
+++ b/Tests/NostrSDKTests/Fixtures/ok_fail_reason.json
@@ -1,0 +1,1 @@
+["OK", "b1a649ebe8b435ec71d3784793f3bbf4b93e64e17568a741aecd4c7ddeafce30", false, "blocked: tor exit nodes not allowed"]

--- a/Tests/NostrSDKTests/Fixtures/ok_success.json
+++ b/Tests/NostrSDKTests/Fixtures/ok_success.json
@@ -1,0 +1,1 @@
+["OK", "b1a649ebe8b435ec71d3784793f3bbf4b93e64e17568a741aecd4c7ddeafce30", true, ""]

--- a/Tests/NostrSDKTests/Fixtures/ok_success_reason.json
+++ b/Tests/NostrSDKTests/Fixtures/ok_success_reason.json
@@ -1,0 +1,1 @@
+["OK", "b1a649ebe8b435ec71d3784793f3bbf4b93e64e17568a741aecd4c7ddeafce30", true, "pow: difficulty 25>=24"]

--- a/Tests/NostrSDKTests/RelayMessageDecodingTests.swift
+++ b/Tests/NostrSDKTests/RelayMessageDecodingTests.swift
@@ -8,7 +8,7 @@
 @testable import NostrSDK
 import XCTest
 
-final class RelayMessageDecodingTests: XCTestCase {
+final class RelayResponseDecodingTests: XCTestCase {
 
     let fixtureLoader = FixtureLoader()
 

--- a/Tests/NostrSDKTests/RelayMessageDecodingTests.swift
+++ b/Tests/NostrSDKTests/RelayMessageDecodingTests.swift
@@ -139,4 +139,21 @@ final class RelayResponseDecodingTests: XCTestCase {
             XCTFail("failed to decode")
         }
     }
+
+    func testDecodeAuthChallenge() {
+        guard let data = fixtureLoader.loadFixture("auth_challenge") else {
+            XCTFail("failed to load fixture")
+            return
+        }
+
+        if let relayResponse = RelayResponse.decode(data: data) {
+            guard case .auth(let challenge) = relayResponse else {
+                XCTFail("incorrect type")
+                return
+            }
+            XCTAssertEqual(challenge, "some-challenge-string")
+        } else {
+            XCTFail("failed to decode")
+        }
+    }
 }

--- a/Tests/NostrSDKTests/RelayMessageDecodingTests.swift
+++ b/Tests/NostrSDKTests/RelayMessageDecodingTests.swift
@@ -64,4 +64,61 @@ final class RelayMessageDecodingTests: XCTestCase {
             XCTFail("failed to decode")
         }
     }
+
+    func testDecodeOkMessage() {
+        guard let data = fixtureLoader.loadFixture("ok_success") else {
+            XCTFail("failed to load fixture")
+            return
+        }
+
+        if let relayResponse = RelayResponse.decode(data: data) {
+            guard case .ok(let eventId, let success, let message) = relayResponse else {
+                XCTFail("incorrect type")
+                return
+            }
+            XCTAssertEqual(eventId, "b1a649ebe8b435ec71d3784793f3bbf4b93e64e17568a741aecd4c7ddeafce30")
+            XCTAssertEqual(success, true)
+            XCTAssertEqual(message, "")
+        } else {
+            XCTFail("failed to decode")
+        }
+    }
+
+    func testDecodeOkMessageWithReason() {
+        guard let data = fixtureLoader.loadFixture("ok_success_reason") else {
+            XCTFail("failed to load fixture")
+            return
+        }
+
+        if let relayResponse = RelayResponse.decode(data: data) {
+            guard case .ok(let eventId, let success, let message) = relayResponse else {
+                XCTFail("incorrect type")
+                return
+            }
+            XCTAssertEqual(eventId, "b1a649ebe8b435ec71d3784793f3bbf4b93e64e17568a741aecd4c7ddeafce30")
+            XCTAssertEqual(success, true)
+            XCTAssertEqual(message, "pow: difficulty 25>=24")
+        } else {
+            XCTFail("failed to decode")
+        }
+    }
+
+    func testDecodeOkFailWithReason() {
+        guard let data = fixtureLoader.loadFixture("ok_fail_reason") else {
+            XCTFail("failed to load fixture")
+            return
+        }
+
+        if let relayResponse = RelayResponse.decode(data: data) {
+            guard case .ok(let eventId, let success, let message) = relayResponse else {
+                XCTFail("incorrect type")
+                return
+            }
+            XCTAssertEqual(eventId, "b1a649ebe8b435ec71d3784793f3bbf4b93e64e17568a741aecd4c7ddeafce30")
+            XCTAssertEqual(success, false)
+            XCTAssertEqual(message, "blocked: tor exit nodes not allowed")
+        } else {
+            XCTFail("failed to decode")
+        }
+    }
 }

--- a/Tests/NostrSDKTests/RelayMessageDecodingTests.swift
+++ b/Tests/NostrSDKTests/RelayMessageDecodingTests.swift
@@ -1,0 +1,67 @@
+//
+//  RelayMessageDecodingTests.swift
+//  
+//
+//  Created by Joel Klabo on 5/25/23.
+//
+
+@testable import NostrSDK
+import XCTest
+
+final class RelayMessageDecodingTests: XCTestCase {
+
+    let fixtureLoader = FixtureLoader()
+
+    func testDecodeNoticeMessage() {
+        guard let data = fixtureLoader.loadFixture("notice") else {
+            XCTFail("failed to load fixture")
+            return
+        }
+
+        if let relayResponse = RelayResponse.decode(data: data) {
+            guard case .notice(let message) = relayResponse else {
+                XCTFail("incorrect type")
+                return
+            }
+            XCTAssertEqual(message, "there was an error")
+        } else {
+            XCTFail("failed to decode")
+        }
+    }
+
+    func testDecodeEOSEMessage() {
+        guard let data = fixtureLoader.loadFixture("eose") else {
+            XCTFail("failed to load fixture")
+            return
+        }
+
+        if let relayResponse = RelayResponse.decode(data: data) {
+            guard case .eose(let subscriptionId) = relayResponse else {
+                XCTFail("incorrect type")
+                return
+            }
+            XCTAssertEqual(subscriptionId, "some-subscription-id")
+        } else {
+            XCTFail("failed to decode")
+        }
+    }
+
+    func testDecodeEventMessage() {
+        guard let data = fixtureLoader.loadFixture("event") else {
+            XCTFail("failed to load fixture")
+            return
+        }
+
+        if let relayResponse = RelayResponse.decode(data: data) {
+            guard case .event(let subscriptionId, let event) = relayResponse else {
+                XCTFail("incorrect type")
+                return
+            }
+            XCTAssertEqual(subscriptionId, "some-subscription-id")
+            XCTAssertNotNil(event)
+            XCTAssertEqual(event.id, "fa5ed84fc8eeb959fd39ad8e48388cfc33075991ef8e50064cfcecfd918bb91b")
+        } else {
+            XCTFail("failed to decode")
+        }
+    }
+}

--- a/Tests/NostrSDKTests/RelayMessageDecodingTests.swift
+++ b/Tests/NostrSDKTests/RelayMessageDecodingTests.swift
@@ -121,4 +121,22 @@ final class RelayMessageDecodingTests: XCTestCase {
             XCTFail("failed to decode")
         }
     }
+
+    func testDecodeCount() {
+        guard let data = fixtureLoader.loadFixture("count_response") else {
+            XCTFail("failed to load fixture")
+            return
+        }
+
+        if let relayResponse = RelayResponse.decode(data: data) {
+            guard case .count(let subscriptionId, let count) = relayResponse else {
+                XCTFail("incorrect type")
+                return
+            }
+            XCTAssertEqual(subscriptionId, "subscription-id")
+            XCTAssertEqual(count, 238)
+        } else {
+            XCTFail("failed to decode")
+        }
+    }
 }


### PR DESCRIPTION
Adding parsing for relay response messages: `NOTICE`, `OK`, `EOSE`, `COUNT`, `AUTH`, and `EVENT`

Ignoring `identifier_name` SwiftLint rule so we can have the `.ok` enum case