### PR TITLE
convert FixtureLoader to a protocol extension FixtureLoading, make function throw for simpler call sites

### DIFF
--- a/Tests/NostrSDKTests/EventDecodingTests.swift
+++ b/Tests/NostrSDKTests/EventDecodingTests.swift
@@ -8,15 +8,10 @@
 @testable import NostrSDK
 import XCTest
 
-final class EventDecodingTests: XCTestCase {
-
-    let fixtureLoader = FixtureLoader()
+final class EventDecodingTests: XCTestCase, FixtureLoading {
 
     func testDecodeSetMetadata() throws {
-        guard let data = fixtureLoader.loadFixture("set_metadata") else {
-            XCTFail("failed to load fixture")
-            return
-        }
+        let data = try loadFixture("set_metadata")
 
         let event = try JSONDecoder().decode(NostrEvent.self, from: data)
 
@@ -30,10 +25,7 @@ final class EventDecodingTests: XCTestCase {
     }
 
     func testDecodeTextNote() throws {
-        guard let data = fixtureLoader.loadFixture("text_note") else {
-            XCTFail("failed to load fixture")
-            return
-        }
+        let data = try loadFixture("text_note")
 
         let event = try JSONDecoder().decode(NostrEvent.self, from: data)
 
@@ -52,10 +44,7 @@ final class EventDecodingTests: XCTestCase {
     }
 
     func testDecodeRepost() throws {
-        guard let data = fixtureLoader.loadFixture("repost") else {
-            XCTFail("failed to load fixture")
-            return
-        }
+        let data = try loadFixture("repost")
 
         let event = try JSONDecoder().decode(NostrEvent.self, from: data)
 

--- a/Tests/NostrSDKTests/FixtureLoading.swift
+++ b/Tests/NostrSDKTests/FixtureLoading.swift
@@ -1,5 +1,5 @@
 //
-//  FixtureLoader.swift
+//  FixtureLoading.swift
 //  
 //
 //  Created by Joel Klabo on 5/24/23.
@@ -7,16 +7,20 @@
 
 import Foundation
 
-class FixtureLoader {
-    func loadFixture(_ filename: String) -> Data? {
+enum FixtureLoadingError: Error {
+    case missingFile
+}
+
+protocol FixtureLoading {}
+extension FixtureLoading {
+    
+    func loadFixture(_ filename: String) throws -> Data {
         // Construct the URL for the fixtures directory.
         let bundle = Bundle.module
         guard let url = bundle.url(forResource: filename, withExtension: "json", subdirectory: "Fixtures") else {
-            return nil
+            throw FixtureLoadingError.missingFile
         }
         // Load the data from the file.
-        let data = try? Data(contentsOf: url)
-
-        return data
+        return try Data(contentsOf: url)
     }
 }

--- a/Tests/NostrSDKTests/FixtureLoading.swift
+++ b/Tests/NostrSDKTests/FixtureLoading.swift
@@ -13,7 +13,7 @@ enum FixtureLoadingError: Error {
 
 protocol FixtureLoading {}
 extension FixtureLoading {
-    
+
     func loadFixture(_ filename: String) throws -> Data {
         // Construct the URL for the fixtures directory.
         let bundle = Bundle.module

--- a/Tests/NostrSDKTests/RelayMessageDecodingTests.swift
+++ b/Tests/NostrSDKTests/RelayMessageDecodingTests.swift
@@ -8,15 +8,10 @@
 @testable import NostrSDK
 import XCTest
 
-final class RelayResponseDecodingTests: XCTestCase {
+final class RelayResponseDecodingTests: XCTestCase, FixtureLoading {
 
-    let fixtureLoader = FixtureLoader()
-
-    func testDecodeNoticeMessage() {
-        guard let data = fixtureLoader.loadFixture("notice") else {
-            XCTFail("failed to load fixture")
-            return
-        }
+    func testDecodeNoticeMessage() throws {
+        let data = try loadFixture("notice")
 
         if let relayResponse = RelayResponse.decode(data: data) {
             guard case .notice(let message) = relayResponse else {
@@ -29,11 +24,8 @@ final class RelayResponseDecodingTests: XCTestCase {
         }
     }
 
-    func testDecodeEOSEMessage() {
-        guard let data = fixtureLoader.loadFixture("eose") else {
-            XCTFail("failed to load fixture")
-            return
-        }
+    func testDecodeEOSEMessage() throws {
+        let data = try loadFixture("eose")
 
         if let relayResponse = RelayResponse.decode(data: data) {
             guard case .eose(let subscriptionId) = relayResponse else {
@@ -46,11 +38,8 @@ final class RelayResponseDecodingTests: XCTestCase {
         }
     }
 
-    func testDecodeEventMessage() {
-        guard let data = fixtureLoader.loadFixture("event") else {
-            XCTFail("failed to load fixture")
-            return
-        }
+    func testDecodeEventMessage() throws {
+        let data = try loadFixture("event")
 
         if let relayResponse = RelayResponse.decode(data: data) {
             guard case .event(let subscriptionId, let event) = relayResponse else {
@@ -65,11 +54,8 @@ final class RelayResponseDecodingTests: XCTestCase {
         }
     }
 
-    func testDecodeOkMessage() {
-        guard let data = fixtureLoader.loadFixture("ok_success") else {
-            XCTFail("failed to load fixture")
-            return
-        }
+    func testDecodeOkMessage() throws {
+        let data = try loadFixture("ok_success")
 
         if let relayResponse = RelayResponse.decode(data: data) {
             guard case .ok(let eventId, let success, let message) = relayResponse else {
@@ -84,11 +70,8 @@ final class RelayResponseDecodingTests: XCTestCase {
         }
     }
 
-    func testDecodeOkMessageWithReason() {
-        guard let data = fixtureLoader.loadFixture("ok_success_reason") else {
-            XCTFail("failed to load fixture")
-            return
-        }
+    func testDecodeOkMessageWithReason() throws {
+        let data = try loadFixture("ok_success_reason")
 
         if let relayResponse = RelayResponse.decode(data: data) {
             guard case .ok(let eventId, let success, let message) = relayResponse else {
@@ -103,11 +86,8 @@ final class RelayResponseDecodingTests: XCTestCase {
         }
     }
 
-    func testDecodeOkFailWithReason() {
-        guard let data = fixtureLoader.loadFixture("ok_fail_reason") else {
-            XCTFail("failed to load fixture")
-            return
-        }
+    func testDecodeOkFailWithReason() throws {
+        let data = try loadFixture("ok_fail_reason")
 
         if let relayResponse = RelayResponse.decode(data: data) {
             guard case .ok(let eventId, let success, let message) = relayResponse else {
@@ -122,11 +102,8 @@ final class RelayResponseDecodingTests: XCTestCase {
         }
     }
 
-    func testDecodeCount() {
-        guard let data = fixtureLoader.loadFixture("count_response") else {
-            XCTFail("failed to load fixture")
-            return
-        }
+    func testDecodeCount() throws {
+        let data = try loadFixture("count_response")
 
         if let relayResponse = RelayResponse.decode(data: data) {
             guard case .count(let subscriptionId, let count) = relayResponse else {
@@ -140,11 +117,8 @@ final class RelayResponseDecodingTests: XCTestCase {
         }
     }
 
-    func testDecodeAuthChallenge() {
-        guard let data = fixtureLoader.loadFixture("auth_challenge") else {
-            XCTFail("failed to load fixture")
-            return
-        }
+    func testDecodeAuthChallenge() throws {
+        let data = try loadFixture("auth_challenge")
 
         if let relayResponse = RelayResponse.decode(data: data) {
             guard case .auth(let challenge) = relayResponse else {


### PR DESCRIPTION
This PR converts `FixtureLoader` to a protocol extension `FixtureLoading` and makes its function throw for simpler call sites. It illustrates how lightweight and simple a protocol extension is and when it can be used to replace a class.