### PR TITLE
simplify decodeFixture

### DIFF
--- a/Tests/NostrSDKTests/EventDecodingTests.swift
+++ b/Tests/NostrSDKTests/EventDecodingTests.swift
@@ -12,7 +12,7 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
 
     func testDecodeSetMetadata() throws {
 
-        let event = try decodeFixture(type: NostrEvent.self, filename: "set_metadata")
+        let event: NostrEvent = try decodeFixture(filename: "set_metadata")
 
         XCTAssertEqual(event.id, "d214c914b0ab49ec919fa5f60fabf746f421e432d96f941bd2573e4d22e36b51")
         XCTAssertEqual(event.pubkey, "00000000827ffaa94bfea288c3dfce4422c794fbb96625b6b31e9049f729d700")
@@ -25,7 +25,7 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
 
     func testDecodeTextNote() throws {
 
-        let event = try decodeFixture(type: NostrEvent.self, filename: "text_note")
+        let event: NostrEvent = try decodeFixture(filename: "text_note")
 
         XCTAssertEqual(event.id, "fa5ed84fc8eeb959fd39ad8e48388cfc33075991ef8e50064cfcecfd918bb91b")
         XCTAssertEqual(event.pubkey, "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2")
@@ -43,7 +43,7 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
     
     func testDecodeContactList() throws {
 
-        let event = try decodeFixture(type: NostrEvent.self, filename: "contact_list")
+        let event: NostrEvent = try decodeFixture(filename: "contact_list")
         
         XCTAssertEqual(event.id, "test-id")
         XCTAssertEqual(event.pubkey, "test-pubkey")
@@ -60,7 +60,7 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
     
     func testDecodeRepost() throws {
         
-        let event = try decodeFixture(type: NostrEvent.self, filename: "repost")
+        let event: NostrEvent = try decodeFixture(filename: "repost")
 
         XCTAssertEqual(event.id, "9353c66d99d600f51b9b1f309b804d2156facd227d643eb513eb8c508498da21")
         XCTAssertEqual(event.pubkey, "91c9a5e1a9744114c6fe2d61ae4de82629eaaa0fb52f48288093c7e7e036f832")

--- a/Tests/NostrSDKTests/FixtureLoading.swift
+++ b/Tests/NostrSDKTests/FixtureLoading.swift
@@ -32,15 +32,9 @@ extension FixtureLoading {
         return trimmedString
     }
 
-    func decodeFixture<T: Decodable>(type: T.Type, filename: String) throws -> T {
-        do {
-            let data = try loadFixtureData(filename)
-            let decoder = JSONDecoder()
-            let instance = try decoder.decode(T.self, from: data)
-            return instance
-        } catch {
-            throw FixtureLoadingError.decodingError
-        }
+    func decodeFixture<T: Decodable>(filename: String) throws -> T {
+        let data = try loadFixtureData(filename)
+        return try JSONDecoder().decode(T.self, from: data)
     }
 
 }


### PR DESCRIPTION
This PR simplifies `decodeFixture`. Since we are already in a throwing context, there's no need to use `do-catch`. And we can pass the generic type in by specifying the type of the return parameter at the call site rather than as a parameter into the function.