### PR TITLE
add support and test for NIP-11 Relay Information Document

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,6 +2,7 @@ disabled_rules:
   - line_length
   - identifier_name
   - trailing_whitespace
+  - nesting
 
 excluded:
   - .build

--- a/Sources/NostrSDK/RelayInfo.swift
+++ b/Sources/NostrSDK/RelayInfo.swift
@@ -16,7 +16,6 @@ public struct RelayInfo: Codable {
     public let contactPubkey: String?
     public let alternativeContact: String?
     public let supportedNIPs: [Int]?
-    public let supportedNIPExtensions: [String]?
     public let software: String?
     public let version: String?
     public let limitations: Limitations?
@@ -33,7 +32,6 @@ public struct RelayInfo: Codable {
         case contactPubkey = "pubkey"
         case alternativeContact = "contact"
         case supportedNIPs = "supported_nips"
-        case supportedNIPExtensions = "supported_nip_extensions"
         case software, version
         case limitations = "limitation"
         case paymentsURL = "payments_url"

--- a/Sources/NostrSDK/RelayInfo.swift
+++ b/Sources/NostrSDK/RelayInfo.swift
@@ -1,0 +1,134 @@
+//
+//  RelayInfo.swift
+//  
+//
+//  Created by Bryan Montz on 6/4/23.
+//
+
+import Foundation
+
+// NIP-11 Relay Information Document
+// https://github.com/nostr-protocol/nips/blob/master/11.md
+
+public struct RelayInfo: Codable {
+    public let name: String?
+    public let description: String?
+    public let contactPubkey: String?
+    public let alternativeContact: String?
+    public let supportedNIPs: [Int]?
+    public let supportedNIPExtensions: [String]?
+    public let software: String?
+    public let version: String?
+    public let limitations: Limitations?
+    public let paymentsURL: String?
+    public let fees: Fees?
+    public let relayCountries: [String]?
+    public let languageTags: [String]?
+    public let tags: [String]?
+    public let postingPolicyURL: String?
+    public let retentionPolicies: [EventRetentionPolicy]?
+    
+    enum CodingKeys: String, CodingKey {
+        case name, description
+        case contactPubkey = "pubkey"
+        case alternativeContact = "contact"
+        case supportedNIPs = "supported_nips"
+        case supportedNIPExtensions = "supported_nip_extensions"
+        case software, version
+        case limitations = "limitation"
+        case paymentsURL = "payments_url"
+        case fees
+        case relayCountries = "relay_countries"
+        case languageTags = "language_tags"
+        case tags
+        case postingPolicyURL = "posting_policy"
+        case retentionPolicies = "retention"
+    }
+    
+    public struct Limitations: Codable {
+        public let maxMessageLength: Int?
+        public let maxSubscriptions: Int?
+        public let maxFilters: Int?
+        public let maxLimit: Int?
+        public let maxSubscriptionIdLength: Int?
+        public let minPrefix: Int?
+        public let maxEventTags: Int?
+        public let maxContentLength: Int?
+        public let minProofOfWorkDifficulty: Int?
+        public let isAuthenticationRequired: Bool?
+        public let isPaymentRequired: Bool?
+        
+        enum CodingKeys: String, CodingKey {
+            case maxMessageLength = "max_message_length"
+            case maxSubscriptions = "max_subscriptions"
+            case maxFilters = "max_filters"
+            case maxLimit = "max_limit"
+            case maxSubscriptionIdLength = "max_subid_length"
+            case minPrefix = "min_prefix"
+            case maxEventTags = "max_event_tags"
+            case maxContentLength = "max_content_length"
+            case minProofOfWorkDifficulty = "min_pow_difficulty"
+            case isAuthenticationRequired = "auth_required"
+            case isPaymentRequired = "payment_required"
+        }
+    }
+    
+    public struct Fee: Codable {
+        public let kinds: [Int]?
+        public let amount: Int?
+        public let unit: String?
+        public let period: Int?
+    }
+    
+    public struct Fees: Codable {
+        public let admission: [Fee]?
+        public let subscription: [Fee]?
+        public let publication: [Fee]?
+    }
+    
+    public struct EventRetentionPolicy: Codable {
+        public let time: Int?
+        public let count: Int?
+        public let kindRanges: [ClosedRange<Int>]?
+        
+        enum CodingKeys: String, CodingKey {
+            case time, count
+            case kindRanges = "kinds"
+        }
+        
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            time = try container.decodeIfPresent(Int.self, forKey: .time)
+            count = try container.decodeIfPresent(Int.self, forKey: .count)
+            
+            if container.contains(.kindRanges) {
+                var kindRanges = [ClosedRange<Int>]()
+                var kindsContainer = try container.nestedUnkeyedContainer(forKey: .kindRanges)
+                while !kindsContainer.isAtEnd {
+                    if let intValue = try? kindsContainer.decode(Int.self) {
+                        kindRanges.append(intValue...intValue)
+                    } else if let intArray = try? kindsContainer.decode([Int].self) {
+                        if intArray.count == 2 {
+                            kindRanges.append(intArray[0]...intArray[1])
+                        } else {
+                            break // invalid data, fail silently since retention data is optional
+                        }
+                    } else {
+                        break   // invalid data
+                    }
+                }
+                self.kindRanges = kindRanges
+            } else {
+                kindRanges = nil
+            }
+        }
+        
+        public func governsKind(_ kind: Int) -> Bool {
+            kindRanges?.contains(where: { $0.contains(kind) }) ?? false
+        }
+    }
+    
+    public func retentionPolicy(forKind kind: Int) -> EventRetentionPolicy? {
+        retentionPolicies?.first(where: { $0.governsKind(kind) }) ?? retentionPolicies?.first(where: { $0.kindRanges == nil })
+    }
+}

--- a/Tests/NostrSDKTests/Fixtures/relay_info.json
+++ b/Tests/NostrSDKTests/Fixtures/relay_info.json
@@ -33,7 +33,7 @@
         { "kinds": [[30000, 39999]], "count": 1000 },
         { "time": 3600, "count": 10000 }
     ],
-    "language_tags": [ "en", "en-419" ],
+    "language_tags": [ "en", "es" ],
     "tags": [ "sfw-only", "bitcoin-only", "anime" ],
     "posting_policy": "https://nostr.test/posting-policy.html",
     "relay_countries": [ "CA", "US" ],

--- a/Tests/NostrSDKTests/Fixtures/relay_info.json
+++ b/Tests/NostrSDKTests/Fixtures/relay_info.json
@@ -1,0 +1,46 @@
+{
+    "name": "nostr.test",
+    "description": "Nostr Test",
+    "pubkey": "test-pubkey",
+    "contact": "mailto:somebody@nostr.test",
+    "supported_nips": [
+        1,
+        2,
+        4,
+        9
+    ],
+    "supported_nip_extensions": [
+        "11a"
+    ],
+    "software": "git+https://github.com/Cameri/nostream.git",
+    "version": "1.25.2",
+    "limitation": {
+        "max_message_length": 1048576,
+        "max_subscriptions": 10,
+        "max_filters": 2500,
+        "max_limit": 5000,
+        "max_subid_length": 256,
+        "min_prefix": 4,
+        "max_event_tags": 2500,
+        "max_content_length": 65536,
+        "min_pow_difficulty": 0,
+        "auth_required": false,
+        "payment_required": true
+    },
+    "retention": [
+        { "kinds": [0, 1, [5, 7], [40, 49]], "time": 3600 },
+        { "kinds": [[40000, 49999]], "time": 100 },
+        { "kinds": [[30000, 39999]], "count": 1000 },
+        { "time": 3600, "count": 10000 }
+    ],
+    "language_tags": [ "en", "en-419" ],
+    "tags": [ "sfw-only", "bitcoin-only", "anime" ],
+    "posting_policy": "https://nostr.test/posting-policy.html",
+    "relay_countries": [ "CA", "US" ],
+    "payments_url": "https://nostr.test/invoices",
+    "fees": {
+        "admission": [{ "amount": 1000000, "unit": "msats" }],
+        "subscription": [{ "amount": 5000000, "unit": "msats", "period": 2592000 }],
+        "publication": [{ "kinds": [4], "amount": 100, "unit": "msats" }],
+    }
+}

--- a/Tests/NostrSDKTests/RelayInfoTests.swift
+++ b/Tests/NostrSDKTests/RelayInfoTests.swift
@@ -18,12 +18,11 @@ final class RelayInfoTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(info.contactPubkey, "test-pubkey")
         XCTAssertEqual(info.alternativeContact, "mailto:somebody@nostr.test")
         XCTAssertEqual(info.supportedNIPs, [1, 2, 4, 9])
-        XCTAssertEqual(info.supportedNIPExtensions, ["11a"])
         XCTAssertEqual(info.software, "git+https://github.com/Cameri/nostream.git")
         XCTAssertEqual(info.version, "1.25.2")
         XCTAssertEqual(info.relayCountries, ["CA", "US"])
         XCTAssertEqual(info.paymentsURL, "https://nostr.test/invoices")
-        XCTAssertEqual(info.languageTags, ["en", "en-419"])
+        XCTAssertEqual(info.languageTags, ["en", "es"])
         XCTAssertEqual(info.tags, ["sfw-only", "bitcoin-only", "anime"])
         XCTAssertEqual(info.postingPolicyURL, "https://nostr.test/posting-policy.html")
         

--- a/Tests/NostrSDKTests/RelayInfoTests.swift
+++ b/Tests/NostrSDKTests/RelayInfoTests.swift
@@ -1,0 +1,72 @@
+//
+//  RelayInformationTests.swift
+//  
+//
+//  Created by Bryan Montz on 6/4/23.
+//
+
+@testable import NostrSDK
+import XCTest
+
+final class RelayInfoTests: XCTestCase, FixtureLoading {
+
+    func testDecodeRelayInformation() throws {
+        let info: RelayInfo = try decodeFixture(filename: "relay_info")
+        
+        XCTAssertEqual(info.name, "nostr.test")
+        XCTAssertEqual(info.description, "Nostr Test")
+        XCTAssertEqual(info.contactPubkey, "test-pubkey")
+        XCTAssertEqual(info.alternativeContact, "mailto:somebody@nostr.test")
+        XCTAssertEqual(info.supportedNIPs, [1, 2, 4, 9])
+        XCTAssertEqual(info.supportedNIPExtensions, ["11a"])
+        XCTAssertEqual(info.software, "git+https://github.com/Cameri/nostream.git")
+        XCTAssertEqual(info.version, "1.25.2")
+        XCTAssertEqual(info.relayCountries, ["CA", "US"])
+        XCTAssertEqual(info.paymentsURL, "https://nostr.test/invoices")
+        XCTAssertEqual(info.languageTags, ["en", "en-419"])
+        XCTAssertEqual(info.tags, ["sfw-only", "bitcoin-only", "anime"])
+        XCTAssertEqual(info.postingPolicyURL, "https://nostr.test/posting-policy.html")
+        
+        XCTAssertEqual(info.limitations?.maxMessageLength, 1048576)
+        XCTAssertEqual(info.limitations?.maxSubscriptions, 10)
+        XCTAssertEqual(info.limitations?.maxFilters, 2500)
+        XCTAssertEqual(info.limitations?.maxLimit, 5000)
+        XCTAssertEqual(info.limitations?.maxSubscriptionIdLength, 256)
+        XCTAssertEqual(info.limitations?.minPrefix, 4)
+        XCTAssertEqual(info.limitations?.maxEventTags, 2500)
+        XCTAssertEqual(info.limitations?.maxContentLength, 65536)
+        XCTAssertEqual(info.limitations?.minProofOfWorkDifficulty, 0)
+        XCTAssertEqual(info.limitations?.isAuthenticationRequired, false)
+        XCTAssertEqual(info.limitations?.isPaymentRequired, true)
+        
+        let admissionFee = try XCTUnwrap(info.fees?.admission?.first)
+        XCTAssertEqual(admissionFee.amount, 1000000)
+        XCTAssertEqual(admissionFee.unit, "msats")
+        XCTAssertNil(admissionFee.period)
+        XCTAssertNil(admissionFee.kinds)
+        
+        let subscriptionFee = try XCTUnwrap(info.fees?.subscription?.first)
+        XCTAssertEqual(subscriptionFee.amount, 5000000)
+        XCTAssertEqual(subscriptionFee.unit, "msats")
+        XCTAssertEqual(subscriptionFee.period, 2592000)
+        XCTAssertNil(subscriptionFee.kinds)
+        
+        let publicationFee = try XCTUnwrap(info.fees?.publication?.first)
+        XCTAssertEqual(publicationFee.amount, 100)
+        XCTAssertEqual(publicationFee.unit, "msats")
+        XCTAssertNil(publicationFee.period)
+        XCTAssertEqual(publicationFee.kinds, [4])
+        
+        let kind1Policy = try XCTUnwrap(info.retentionPolicy(forKind: 1))
+        XCTAssertEqual(kind1Policy.time, 3600)
+        XCTAssertNil(kind1Policy.count)
+        
+        let kind30kPolicy = try XCTUnwrap(info.retentionPolicy(forKind: 31234))
+        XCTAssertEqual(kind30kPolicy.count, 1000)
+        XCTAssertNil(kind30kPolicy.time)
+        
+        let unspecifiedKindRetention = try XCTUnwrap(info.retentionPolicy(forKind: 75))
+        XCTAssertEqual(unspecifiedKindRetention.time, 3600)
+        XCTAssertEqual(unspecifiedKindRetention.count, 10000)
+    }
+}


### PR DESCRIPTION
This PR adds support for NIP-11 Relay Information Document decoding. These properties will give clients all the necessary information a relay offers about its service.