### PR TITLE
Add NIP-25 reactions

### DIFF
--- a/Sources/NostrSDK/EventCreating.swift
+++ b/Sources/NostrSDK/EventCreating.swift
@@ -40,7 +40,7 @@ public extension EventCreating {
         try TextNoteEvent(kind: .textNote, content: content, signedBy: keypair)
     }
     
-    /// Creates a recommend server event (kind 2) and signs it with the provided `Keypair``.`
+    /// Creates a recommend server event (kind 2) and signs it with the provided ``Keypair``.
     /// - Parameters:
     ///   - relayURL: The URL of the relay, which must be a websocket URL.
     ///   - keypair: The Keypair to sign with.
@@ -53,5 +53,24 @@ public extension EventCreating {
             throw EventCreatingError.invalidInput
         }
         return try RecommendServerEvent(kind: .recommendServer, content: relayURL.absoluteString, signedBy: keypair)
+    }
+
+    /// Creates a reaction event (kind 7) in response to a different ``NostrEvent`` and signs it with the provided ``Keypair``.
+    /// - Parameters:
+    ///   - content: The content of the reaction.
+    ///   - reactedEvent: The NostrEvent being reacted to.
+    ///   - keypair: The Keypair to sign with.
+    /// - Returns: The signed reaction event.
+    ///
+    /// See [NIP-25 - Reactions](https://github.com/nostr-protocol/nips/blob/master/25.md)
+    func reaction(withContent content: String, reactedEvent: NostrEvent, signedBy keypair: Keypair) throws -> ReactionEvent {
+        let eventTag = Tag(name: .event, value: reactedEvent.id)
+        let pubkeyTag = Tag(name: .pubkey, value: reactedEvent.pubkey)
+
+        var tags = reactedEvent.tags.filter { $0.name == .event || $0.name == .pubkey }
+        tags.append(eventTag)
+        tags.append(pubkeyTag)
+
+        return try ReactionEvent(kind: .reaction, content: content, tags: tags, signedBy: keypair)
     }
 }

--- a/Sources/NostrSDK/EventKind.swift
+++ b/Sources/NostrSDK/EventKind.swift
@@ -38,7 +38,12 @@ public enum EventKind: RawRepresentable, CaseIterable, Codable, Equatable {
     /// > Note: The reposted event must be a kind 1 text note.
     /// See [NIP-18](https://github.com/nostr-protocol/nips/blob/master/18.md#nip-18).
     case repost
-    
+
+    /// This kind of note is used to signal a reaction to other notes.
+    ///
+    /// See [NIP-25 - Reactions](https://github.com/nostr-protocol/nips/blob/master/25.md)
+    case reaction
+
     /// This kind of note is used to signal to followers that another event is worth reading.
     ///
     /// > Note: The reposted event can be any kind of event other than a kind 1 text note.
@@ -55,6 +60,7 @@ public enum EventKind: RawRepresentable, CaseIterable, Codable, Equatable {
         .recommendServer,
         .contactList,
         .repost,
+        .reaction,
         .genericRepost
     ]
 
@@ -70,6 +76,7 @@ public enum EventKind: RawRepresentable, CaseIterable, Codable, Equatable {
         case .recommendServer: return 2
         case .contactList: return 3
         case .repost: return 6
+        case .reaction: return 7
         case .genericRepost: return 16
         case let .unknown(value): return value
         }

--- a/Sources/NostrSDK/Events/ReactionEvent.swift
+++ b/Sources/NostrSDK/Events/ReactionEvent.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ReactionEvent.swift
 //  
 //
 //  Created by Terry Yiu on 8/12/23.

--- a/Sources/NostrSDK/Events/ReactionEvent.swift
+++ b/Sources/NostrSDK/Events/ReactionEvent.swift
@@ -1,0 +1,21 @@
+//
+//  File.swift
+//  
+//
+//  Created by Terry Yiu on 8/12/23.
+//
+
+import Foundation
+
+/// A reaction event (kind 7) in response to a different event.
+///
+/// See [NIP-25](https://github.com/nostr-protocol/nips/blob/master/25.md).
+public class ReactionEvent: NostrEvent {
+    public var reactedEventId: String? {
+        tags.last(where: { $0.name == .event })?.value
+    }
+
+    public var reactedEventPubkey: String? {
+        tags.last(where: { $0.name == .pubkey })?.value
+    }
+}

--- a/Tests/NostrSDKTests/EventCreatingTests.swift
+++ b/Tests/NostrSDKTests/EventCreatingTests.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import NostrSDK
+@testable import NostrSDK
 import XCTest
 
 final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying {
@@ -60,5 +60,27 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying {
         let inputURL = URL(string: "https://not-a-socket.com")!
         XCTAssertThrowsError(try recommendServerEvent(withRelayURL: inputURL,
                                                       signedBy: Keypair.test))
+    }
+
+    func testCreateReactionEvent() throws {
+        let reactedEvent = try textNote(withContent: "Hello world!",
+                                signedBy: Keypair.test)
+        let event = try reaction(withContent: "🤙",
+                                 reactedEvent: reactedEvent,
+                                 signedBy: Keypair.test)
+
+        XCTAssertEqual(event.kind, .reaction)
+        XCTAssertEqual(event.pubkey, Keypair.test.publicKey.hex)
+        XCTAssertEqual(event.reactedEventId, reactedEvent.id)
+        XCTAssertEqual(event.reactedEventPubkey, reactedEvent.pubkey)
+        XCTAssertEqual(event.content, "🤙")
+
+        let expectedTags = [
+            Tag(name: .event, value: reactedEvent.id),
+            Tag(name: .pubkey, value: reactedEvent.pubkey)
+        ]
+        XCTAssertEqual(event.tags, expectedTags)
+
+        try verifyEvent(event)
     }
 }

--- a/Tests/NostrSDKTests/EventDecodingTests.swift
+++ b/Tests/NostrSDKTests/EventDecodingTests.swift
@@ -158,4 +158,23 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(repostedEvent.id, "test-id")
         XCTAssertEqual(repostedEvent.kind, .recommendServer)
     }
+
+    func testDecodeReaction() throws {
+        let event: ReactionEvent = try decodeFixture(filename: "reaction")
+
+        XCTAssertEqual(event.id, "8a3217770794fabe89adac500dcd5d38966d3ba3cb83fabc97b58135980f76cd")
+        XCTAssertEqual(event.pubkey, "2779f3d9f42c7dee17f0e6bcdcf89a8f9d592d19e3b1bbd27ef1cffd1a7f98d1")
+        XCTAssertEqual(event.createdAt, 1689029084)
+        XCTAssertEqual(event.kind, .reaction)
+
+        let expectedTags = [
+            Tag(name: .event, value: "62dcc905c282dd712bbe6b47d2e40feb333f8a0c39899617f4ca37337199ede0"),
+            Tag(name: .pubkey, value: "e1ff3bfdd4e40315959b08b4fcc8245eaa514637e1d4ec2ae166b743341be1af")
+        ]
+        XCTAssertEqual(event.tags, expectedTags)
+        XCTAssertEqual(event.reactedEventId, "62dcc905c282dd712bbe6b47d2e40feb333f8a0c39899617f4ca37337199ede0")
+        XCTAssertEqual(event.reactedEventPubkey, "e1ff3bfdd4e40315959b08b4fcc8245eaa514637e1d4ec2ae166b743341be1af")
+        XCTAssertEqual(event.content, "🤙")
+        XCTAssertEqual(event.signature, "c0dea5d4612d834e13e0dcfeff71a345f761d868bf27fd5e3fe521b76872d5da3db05375f8739a4bad86189d63720187c08170827990b113b477437f17e4a906")
+    }
 }

--- a/Tests/NostrSDKTests/Fixtures/reaction.json
+++ b/Tests/NostrSDKTests/Fixtures/reaction.json
@@ -1,0 +1,19 @@
+{
+    "content": "🤙",
+    "created_at": 1689029084,
+    "id": "8a3217770794fabe89adac500dcd5d38966d3ba3cb83fabc97b58135980f76cd",
+    "kind": 7,
+    "pubkey": "2779f3d9f42c7dee17f0e6bcdcf89a8f9d592d19e3b1bbd27ef1cffd1a7f98d1",
+    "sig": "c0dea5d4612d834e13e0dcfeff71a345f761d868bf27fd5e3fe521b76872d5da3db05375f8739a4bad86189d63720187c08170827990b113b477437f17e4a906",
+    "tags":
+    [
+        [
+            "e",
+            "62dcc905c282dd712bbe6b47d2e40feb333f8a0c39899617f4ca37337199ede0"
+        ],
+        [
+            "p",
+            "e1ff3bfdd4e40315959b08b4fcc8245eaa514637e1d4ec2ae166b743341be1af"
+        ]
+    ]
+}


### PR DESCRIPTION
https://github.com/nostr-protocol/nips/blob/master/25.md

This implementation is missing custom emoji reactions, but I want to handle that in a separate PR because custom emojis can be used in other places outside of reactions.
https://github.com/nostr-protocol/nips/blob/master/25.md#custom-emoji-reaction