### PR TITLE
fix tags

### DIFF
--- a/Sources/NostrSDK/Events/TextNoteEvent.swift
+++ b/Sources/NostrSDK/Events/TextNoteEvent.swift
@@ -14,13 +14,13 @@ public final class TextNoteEvent: NostrEvent {
     
     /// Pubkeys mentioned in the note content.
     public var mentionedPubkeys: [String] {
-        let pubkeyTags = tags.filter { $0.identifier == .pubkey }
-        return pubkeyTags.map { $0.contentIdentifier }
+        let pubkeyTags = tags.filter { $0.name == .pubkey }
+        return pubkeyTags.map { $0.value }
     }
     
     /// Events mentioned in the note content.
     public var mentionedEventIds: [String] {
-        let eventTags = tags.filter { $0.identifier == .event }
-        return eventTags.map { $0.contentIdentifier }
+        let eventTags = tags.filter { $0.name == .event }
+        return eventTags.map { $0.value }
     }
 }

--- a/Tests/NostrSDKTests/EventDecodingTests.swift
+++ b/Tests/NostrSDKTests/EventDecodingTests.swift
@@ -50,8 +50,8 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(event.kind, .textNote)
 
         let expectedTags = [
-            EventTag(contentIdentifier: "93930d65435d49db723499335473920795e7f13c45600dcfad922135cf44bd63"),
-            PubkeyTag(contentIdentifier: "f8e6c64342f1e052480630e27e1016dce35fc3a614e60434fef4aa2503328ca9")
+            Tag(name: .event, value: "93930d65435d49db723499335473920795e7f13c45600dcfad922135cf44bd63"),
+            Tag(name: .pubkey, value: "f8e6c64342f1e052480630e27e1016dce35fc3a614e60434fef4aa2503328ca9")
         ]
         XCTAssertEqual(event.tags, expectedTags)
         XCTAssertEqual(event.content, "I think it stays persistent on your profile, but interface setting doesn’t persist. Bug.  ")
@@ -86,8 +86,8 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(event.kind, .contactList)
         
         let expectedTags: [Tag] = [
-            PubkeyTag(contentIdentifier: "pubkey1", recommendedRelayURL: "wss://relay1.com", petname: "alice"),
-            PubkeyTag(contentIdentifier: "pubkey2", recommendedRelayURL: "wss://relay2.com", petname: "bob")
+            Tag(name: .pubkey, value: "pubkey1", otherParameters: ["wss://relay1.com", "alice"]),
+            Tag(name: .pubkey, value: "pubkey2", otherParameters: ["wss://relay2.com", "bob"])
         ]
         XCTAssertEqual(event.tags, expectedTags)
         XCTAssertEqual(event.signature, "hex-signature")
@@ -103,8 +103,8 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(event.kind, .repost)
 
         let expectedTags = [
-            EventTag(contentIdentifier: "6663efd8ffb35325af90a84cb223dc388e9d355abf7319fe5c4c5ca7f37e9a34"),
-            PubkeyTag(contentIdentifier: "33eecd2e2fae31f36c0bdb843d43611426ee5c023889f0401c1b8f5008e59689")
+            Tag(name: .event, value: "6663efd8ffb35325af90a84cb223dc388e9d355abf7319fe5c4c5ca7f37e9a34"),
+            Tag(name: .pubkey, value: "33eecd2e2fae31f36c0bdb843d43611426ee5c023889f0401c1b8f5008e59689")
         ]
         XCTAssertEqual(event.tags, expectedTags)
         XCTAssertTrue(event.content.hasPrefix("{\"pubkey\":\"33eecd2e2fae31f36c0bdb843d43611426ee5c023889f0401c1b8f5008e59689\""))

--- a/Tests/NostrSDKTests/RelayRequestEncodingTests.swift
+++ b/Tests/NostrSDKTests/RelayRequestEncodingTests.swift
@@ -18,8 +18,8 @@ final class RelayRequestEncodingTests: XCTestCase, FixtureLoading, JSONTesting {
     }
 
     func testEncodeEvent() throws {
-        let eventTag = EventTag(contentIdentifier: "93930d65435d49db723499335473920795e7f13c45600dcfad922135cf44bd63")
-        let pubkeyTag = PubkeyTag(contentIdentifier: "f8e6c64342f1e052480630e27e1016dce35fc3a614e60434fef4aa2503328ca9")
+        let eventTag = Tag(name: .event, value: "93930d65435d49db723499335473920795e7f13c45600dcfad922135cf44bd63")
+        let pubkeyTag = Tag(name: .pubkey, value: "f8e6c64342f1e052480630e27e1016dce35fc3a614e60434fef4aa2503328ca9")
         let event = NostrEvent(id: "fa5ed84fc8eeb959fd39ad8e48388cfc33075991ef8e50064cfcecfd918bb91b",
                                pubkey: "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2",
                                createdAt: 1682080184,


### PR DESCRIPTION
This PR fixes an architectural problem we've seen with how to handle tags. I initially had an incomplete understanding of what a tag on Nostr is.

This change generalizes the `Tag` type to more closely match the Nostr spec. Each tag has a "name" and "value" and "other parameters", just like the README of the NIPs repo describes them. There will no longer be specific types for each name, because they cannot always be interpreted consistently outside the context of a specific event kind. We will still be able to have strongly typed and well-named properties at the event level.