### PR TITLE
add contact list creation and tests

### DIFF
--- a/Sources/NostrSDK/EventCreating.swift
+++ b/Sources/NostrSDK/EventCreating.swift
@@ -75,7 +75,7 @@ public extension EventCreating {
     ///   - keypair: The Keypair to sign with.
     /// - Returns: The signed ``ContactListEvent``.
     ///
-    /// Use this initializer if you do not intend to include petnames as part of the contact list.
+    /// Use this initializer if you intend to include petnames as part of the contact list.
     ///
     /// > Note: [NIP-02 Specification](https://github.com/nostr-protocol/nips/blob/master/02.md#contact-list-and-petnames)
     func contactList(withPubkeyTags pubkeyTags: [Tag], signedBy keypair: Keypair) throws -> ContactListEvent {

--- a/Sources/NostrSDK/EventCreating.swift
+++ b/Sources/NostrSDK/EventCreating.swift
@@ -54,6 +54,37 @@ public extension EventCreating {
         }
         return try RecommendServerEvent(kind: .recommendServer, content: relayURL.absoluteString, signedBy: keypair)
     }
+    
+    /// Creates a ``ContactListEvent`` (kind 3) following the provided pubkeys and signs it with the provided ``Keypair``.
+    /// - Parameters:
+    ///   - pubkeys: The pubkeys of followed/known profiles to add to the contact list, in hex format.
+    ///   - keypair: The Keypair to sign with.
+    /// - Returns: The signed ``ContactListEvent``.
+    ///
+    /// Use this initializer if you do not intend to include petnames as part of the contact list.
+    ///
+    /// > Note: [NIP-02 Specification](https://github.com/nostr-protocol/nips/blob/master/02.md#contact-list-and-petnames)
+    func contactList(withPubkeys pubkeys: [String], signedBy keypair: Keypair) throws -> ContactListEvent {
+        try contactList(withPubkeyTags: pubkeys.map { Tag(name: .pubkey, value: $0) },
+                        signedBy: keypair)
+    }
+    
+    /// Creates a ``ContactListEvent`` (kind 3) with the provided pubkey tags and signs it with the provided ``Keypair``.
+    /// - Parameters:
+    ///   - pubkeyTags: The pubkey tags of followed/known profiles to add to the contact list, which may include petnames.
+    ///   - keypair: The Keypair to sign with.
+    /// - Returns: The signed ``ContactListEvent``.
+    ///
+    /// Use this initializer if you do not intend to include petnames as part of the contact list.
+    ///
+    /// > Note: [NIP-02 Specification](https://github.com/nostr-protocol/nips/blob/master/02.md#contact-list-and-petnames)
+    func contactList(withPubkeyTags pubkeyTags: [Tag], signedBy keypair: Keypair) throws -> ContactListEvent {
+        guard !pubkeyTags.contains(where: { $0.name != .pubkey }) else {
+            throw EventCreatingError.invalidInput
+        }
+        return try ContactListEvent(tags: pubkeyTags,
+                                    signedBy: keypair)
+    }
 
     /// Creates a ``DirectMessageEvent`` (kind 4) and signs it with the provided ``Keypair``.
     /// - Parameters:

--- a/Sources/NostrSDK/Events/ContactListEvent.swift
+++ b/Sources/NostrSDK/Events/ContactListEvent.swift
@@ -32,8 +32,17 @@ public struct RelayPermissions: Equatable {
 /// > Note: [NIP-02 Specification](https://github.com/nostr-protocol/nips/blob/master/02.md#contact-list-and-petnames)
 public final class ContactListEvent: NostrEvent {
     
-    convenience init(tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
-        try self.init(kind: .contactList, content: "", tags: tags, createdAt: createdAt, signedBy: keypair)
+    public required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+    }
+    
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
+    init(tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: .contactList, content: "", tags: tags, createdAt: createdAt, signedBy: keypair)
     }
     
     /// Pubkeys for followed/known profiles.

--- a/Sources/NostrSDK/Events/ContactListEvent.swift
+++ b/Sources/NostrSDK/Events/ContactListEvent.swift
@@ -32,6 +32,10 @@ public struct RelayPermissions: Equatable {
 /// > Note: [NIP-02 Specification](https://github.com/nostr-protocol/nips/blob/master/02.md#contact-list-and-petnames)
 public final class ContactListEvent: NostrEvent {
     
+    convenience init(tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try self.init(kind: .contactList, content: "", tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
     /// Pubkeys for followed/known profiles.
     var contactPubkeys: [String] {
         tags.filter({ $0.name == .pubkey }).map { $0.value }

--- a/Tests/NostrSDKTests/EventCreatingTests.swift
+++ b/Tests/NostrSDKTests/EventCreatingTests.swift
@@ -79,6 +79,8 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying {
         ]
         
         XCTAssertEqual(event.tags, expectedTags)
+        
+        try verifyEvent(event)
     }
     
     func testCreateContactListEventWithPetnames() throws {
@@ -92,6 +94,8 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying {
                                     signedBy: Keypair.test)
         
         XCTAssertEqual(event.tags, tags)
+        
+        try verifyEvent(event)
     }
     
     func testDirectMessageEvent() throws {


### PR DESCRIPTION
Adds the ability to create contact lists from a list of pubkeys or pubkey tags. I provided both options so it can be very simple if the client prefers, but it also has full functionality matching the spec (for petnames).