### PR TITLE
preclude NostrEvent subclasses from using the initializer that allows specifying the kind explicitly

### DIFF
--- a/Sources/NostrSDK/EventCreating.swift
+++ b/Sources/NostrSDK/EventCreating.swift
@@ -26,7 +26,7 @@ public extension EventCreating {
         guard let metadataAsString = String(data: metadataAsData, encoding: .utf8) else {
             throw EventCreatingError.invalidInput
         }
-        return try SetMetadataEvent(kind: .setMetadata, content: metadataAsString, signedBy: keypair)
+        return try SetMetadataEvent(content: metadataAsString, signedBy: keypair)
     }
     
     /// Creates a ``TextNoteEvent`` (kind 1) and signs it with the provided ``Keypair``.
@@ -37,7 +37,7 @@ public extension EventCreating {
     ///
     /// See [NIP-01 - Basic Event Kinds](https://github.com/nostr-protocol/nips/blob/master/01.md#basic-event-kinds)
     func textNote(withContent content: String, signedBy keypair: Keypair) throws -> TextNoteEvent {
-        try TextNoteEvent(kind: .textNote, content: content, signedBy: keypair)
+        try TextNoteEvent(content: content, signedBy: keypair)
     }
     
     /// Creates a ``RecommendServerEvent`` (kind 2) and signs it with the provided ``Keypair``.
@@ -52,7 +52,7 @@ public extension EventCreating {
         guard components?.scheme == "wss" || components?.scheme == "ws" else {
             throw EventCreatingError.invalidInput
         }
-        return try RecommendServerEvent(kind: .recommendServer, content: relayURL.absoluteString, signedBy: keypair)
+        return try RecommendServerEvent(content: relayURL.absoluteString, signedBy: keypair)
     }
     
     /// Creates a ``ContactListEvent`` (kind 3) following the provided pubkeys and signs it with the provided ``Keypair``.
@@ -100,7 +100,7 @@ public extension EventCreating {
         }
 
         let recipientTag = Tag(name: .pubkey, value: pubkey.hex)
-        return try DirectMessageEvent(kind: .directMessage, content: encryptedMessage, tags: [recipientTag], signedBy: keypair)
+        return try DirectMessageEvent(content: encryptedMessage, tags: [recipientTag], signedBy: keypair)
     }
 
     /// Creates a ``ReactionEvent`` (kind 7) in response to a different ``NostrEvent`` and signs it with the provided ``Keypair``.
@@ -119,6 +119,6 @@ public extension EventCreating {
         tags.append(eventTag)
         tags.append(pubkeyTag)
 
-        return try ReactionEvent(kind: .reaction, content: content, tags: tags, signedBy: keypair)
+        return try ReactionEvent(content: content, tags: tags, signedBy: keypair)
     }
 }

--- a/Sources/NostrSDK/Events/DirectMessageEvent.swift
+++ b/Sources/NostrSDK/Events/DirectMessageEvent.swift
@@ -12,6 +12,19 @@ import Foundation
 /// > Note: [NIP-04 Specification](https://github.com/nostr-protocol/nips/blob/master/04.md)
 public final class DirectMessageEvent: NostrEvent, DirectMessageEncrypting {
 
+    public required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+    }
+    
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
+    init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: .directMessage, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
     /// Returns decrypted content from Event given a `privateKey`
     public func decryptedContent(using privateKey: PrivateKey) throws -> String {
         let recipient = tags.first { tag in

--- a/Sources/NostrSDK/Events/ReactionEvent.swift
+++ b/Sources/NostrSDK/Events/ReactionEvent.swift
@@ -11,6 +11,20 @@ import Foundation
 ///
 /// See [NIP-25](https://github.com/nostr-protocol/nips/blob/master/25.md).
 public class ReactionEvent: NostrEvent {
+    
+    public required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+    }
+    
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
+    init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: .reaction, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
     public var reactedEventId: String? {
         tags.last(where: { $0.name == .event })?.value
     }

--- a/Sources/NostrSDK/Events/RecommendServerEvent.swift
+++ b/Sources/NostrSDK/Events/RecommendServerEvent.swift
@@ -11,6 +11,20 @@ import Foundation
 ///
 /// > Note: [NIP-01 Specification](https://github.com/nostr-protocol/nips/blob/b503f8a92b22be3037b8115fe3e644865a4fa155/01.md#basic-event-kinds)
 public final class RecommendServerEvent: NostrEvent {
+    
+    public required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+    }
+    
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
+    init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: .recommendServer, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
     public var relayURL: URL? {
         let components = URLComponents(string: content)
         guard components?.scheme == "wss" || components?.scheme == "ws" else {

--- a/Sources/NostrSDK/Events/SetMetadataEvent.swift
+++ b/Sources/NostrSDK/Events/SetMetadataEvent.swift
@@ -52,6 +52,19 @@ public struct UserMetadata: Codable {
 /// > Note: [NIP-01 Specification](https://github.com/nostr-protocol/nips/blob/b503f8a92b22be3037b8115fe3e644865a4fa155/01.md#basic-event-kinds)
 public final class SetMetadataEvent: NostrEvent {
     
+    public required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+    }
+    
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
+    init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: .setMetadata, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
     /// A dictionary containing all of the properties in the `content` field of the ``NostrEvent``.
     public var rawUserMetadata: [String: Any] {
         guard let data = content.data(using: .utf8) else {

--- a/Sources/NostrSDK/Events/TextNoteEvent.swift
+++ b/Sources/NostrSDK/Events/TextNoteEvent.swift
@@ -12,6 +12,19 @@ import Foundation
 /// > Note: [NIP-01 Specification](https://github.com/nostr-protocol/nips/blob/b503f8a92b22be3037b8115fe3e644865a4fa155/01.md#basic-event-kinds)
 public final class TextNoteEvent: NostrEvent {
     
+    public required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+    }
+    
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
+    init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: .textNote, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
     /// Pubkeys mentioned in the note content.
     public var mentionedPubkeys: [String] {
         let pubkeyTags = tags.filter { $0.name == .pubkey }


### PR DESCRIPTION
Implements the idea from https://github.com/nostr-sdk/nostr-sdk-ios/pull/75 where we want to prevent disparities between the `NostrEvent` subclass and it's `kind` property.