### PR TITLE
Parse display_name

### DIFF
--- a/Sources/NostrSDK/Events/SetMetadataEvent.swift
+++ b/Sources/NostrSDK/Events/SetMetadataEvent.swift
@@ -13,6 +13,9 @@ public struct UserMetadata: Codable {
     /// The user's name.
     public let name: String?
     
+    /// The user's display name.
+    public let displayName: String?
+
     /// The user's description of themself.
     public let about: String?
     
@@ -35,10 +38,12 @@ public struct UserMetadata: Codable {
         case nostrAddress = "nip05"
         case pictureURL = "picture"
         case bannerPictureURL = "banner"
+        case displayName = "display_name"
     }
     
-    public init(name: String?, about: String?, website: URL?, nostrAddress: String?, pictureURL: URL?, bannerPictureURL: URL?) {
+    public init(name: String?, displayName: String?, about: String?, website: URL?, nostrAddress: String?, pictureURL: URL?, bannerPictureURL: URL?) {
         self.name = name
+        self.displayName = displayName
         self.about = about
         self.website = website
         self.nostrAddress = nostrAddress

--- a/Tests/NostrSDKTests/EventCreatingTests.swift
+++ b/Tests/NostrSDKTests/EventCreatingTests.swift
@@ -13,6 +13,7 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
     
     func testCreateSetMetadataEvent() throws {
         let meta = UserMetadata(name: "Nostr SDK Test",
+                                displayName: "Nostr SDK Display Name",
                                 about: "I'm a test account. I'm used to test the Nostr SDK for Apple platforms.",
                                 website: URL(string: "https://github.com/nostr-sdk/nostr-sdk-ios")!,
                                 nostrAddress: "test@nostr.com",
@@ -22,6 +23,7 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
         let event = try setMetadataEvent(withUserMetadata: meta, signedBy: Keypair.test)
         
         XCTAssertEqual(event.userMetadata?.name, "Nostr SDK Test")
+        XCTAssertEqual(event.userMetadata?.displayName, "Nostr SDK Display Name")
         XCTAssertEqual(event.userMetadata?.about, "I'm a test account. I'm used to test the Nostr SDK for Apple platforms.")
         XCTAssertEqual(event.userMetadata?.website, URL(string: "https://github.com/nostr-sdk/nostr-sdk-ios"))
         XCTAssertEqual(event.userMetadata?.nostrAddress, "test@nostr.com")

--- a/Tests/NostrSDKTests/EventDecodingTests.swift
+++ b/Tests/NostrSDKTests/EventDecodingTests.swift
@@ -24,6 +24,7 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         
         // access metadata properties from raw dictionary
         XCTAssertEqual(event.rawUserMetadata["name"] as? String, "cameri")
+        XCTAssertEqual(event.rawUserMetadata["display_name"] as? String, "Cameri 🦦⚡️")
         XCTAssertEqual(event.rawUserMetadata["about"] as? String, "@HodlWithLedn. All opinions are my own.\nBitcoiner class of 2021. Core Nostr Developer. Author of Nostream. Professional Relay Operator.")
         XCTAssertEqual(event.rawUserMetadata["website"] as? String, "https://primal.net/cameri")
         XCTAssertEqual(event.rawUserMetadata["nip05"] as? String, "cameri@elder.nostr.land")


### PR DESCRIPTION
I don't think this is in the spec but it is really common and the default in Damus for example so I think we should have it available if it's there.