### PR TITLE
Fix tags to not have a mapping from name and TagName enum

### DIFF
--- a/Sources/NostrSDK/CustomEmoji.swift
+++ b/Sources/NostrSDK/CustomEmoji.swift
@@ -49,7 +49,7 @@ public extension CustomEmojiInterpreting {
     /// It does not fetch images from the specified URLs to determine if they exist.
     var customEmojis: [CustomEmoji] {
         return tags.compactMap { tag in
-            guard tag.name == .emoji, !tag.otherParameters.isEmpty, let imageURLString = tag.otherParameters.first, let imageURL = URL(string: imageURLString) else {
+            guard tag.name == TagName.emoji.rawValue, !tag.otherParameters.isEmpty, let imageURLString = tag.otherParameters.first, let imageURL = URL(string: imageURLString) else {
                 return nil
             }
 

--- a/Sources/NostrSDK/EventCreating.swift
+++ b/Sources/NostrSDK/EventCreating.swift
@@ -87,7 +87,7 @@ public extension EventCreating {
     ///
     /// > Note: [NIP-02 Specification](https://github.com/nostr-protocol/nips/blob/master/02.md#contact-list-and-petnames)
     func contactList(withPubkeyTags pubkeyTags: [Tag], signedBy keypair: Keypair) throws -> ContactListEvent {
-        guard !pubkeyTags.contains(where: { $0.name != .pubkey }) else {
+        guard !pubkeyTags.contains(where: { $0.name != TagName.pubkey.rawValue }) else {
             throw EventCreatingError.invalidInput
         }
         return try ContactListEvent(tags: pubkeyTags,
@@ -168,7 +168,7 @@ public extension EventCreating {
         let eventTag = Tag(name: .event, value: reactedEvent.id)
         let pubkeyTag = Tag(name: .pubkey, value: reactedEvent.pubkey)
 
-        var tags = reactedEvent.tags.filter { $0.name == .event || $0.name == .pubkey }
+        var tags = reactedEvent.tags.filter { $0.name == TagName.event.rawValue || $0.name == TagName.pubkey.rawValue }
         tags.append(eventTag)
         tags.append(pubkeyTag)
 
@@ -187,7 +187,7 @@ public extension EventCreating {
         let eventTag = Tag(name: .event, value: reactedEvent.id)
         let pubkeyTag = Tag(name: .pubkey, value: reactedEvent.pubkey)
 
-        var tags = reactedEvent.tags.filter { $0.name == .event || $0.name == .pubkey }
+        var tags = reactedEvent.tags.filter { $0.name == TagName.event.rawValue || $0.name == TagName.pubkey.rawValue }
         tags.append(eventTag)
         tags.append(pubkeyTag)
         tags.append(customEmoji.tag)
@@ -299,23 +299,23 @@ public extension EventCreating {
                 throw EventCreatingError.invalidInput
             }
 
-            tags.append(Tag(name: .unknown("end"), value: endDate.dateString))
+            tags.append(Tag(name: "end", value: endDate.dateString))
         }
 
         // Re-arrange tags so that it's easier to read with the identifier and name appearing first in the list of tags,
         // and the end date being placed next to the start date.
         tags = [
-            Tag(name: .unknown("d"), value: UUID().uuidString),
-            Tag(name: .unknown("name"), value: name),
-            Tag(name: .unknown("start"), value: startDate.dateString)
+            Tag(name: .identifier, value: UUID().uuidString),
+            Tag(name: "name", value: name),
+            Tag(name: "start", value: startDate.dateString)
         ] + tags
 
         if let location {
-            tags.append(Tag(name: .unknown("location"), value: location))
+            tags.append(Tag(name: "location", value: location))
         }
 
         if let geohash {
-            tags.append(Tag(name: .unknown("g"), value: geohash))
+            tags.append(Tag(name: "g", value: geohash))
         }
 
         if let participants, !participants.isEmpty {
@@ -327,7 +327,7 @@ public extension EventCreating {
         }
 
         if let references, !references.isEmpty {
-            tags += references.map { Tag(name: .unknown("r"), value: $0.absoluteString) }
+            tags += references.map { Tag(name: .webURL, value: $0.absoluteString) }
         }
 
         return try DateBasedCalendarEvent(content: description, tags: tags, signedBy: keypair)
@@ -361,30 +361,30 @@ public extension EventCreating {
         }
 
         var tags: [Tag] = [
-            Tag(name: .unknown("d"), value: UUID().uuidString),
-            Tag(name: .unknown("name"), value: name),
-            Tag(name: .unknown("start"), value: String(Int64(startTimestamp.timeIntervalSince1970)))
+            Tag(name: .identifier, value: UUID().uuidString),
+            Tag(name: "name", value: name),
+            Tag(name: "start", value: String(Int64(startTimestamp.timeIntervalSince1970)))
         ]
 
         if let endTimestamp {
-            tags.append(Tag(name: .unknown("end"), value: String(Int64(endTimestamp.timeIntervalSince1970))))
+            tags.append(Tag(name: "end", value: String(Int64(endTimestamp.timeIntervalSince1970))))
         }
 
         if let startTimeZone {
-            tags.append(Tag(name: .unknown("start_tzid"), value: startTimeZone.identifier))
+            tags.append(Tag(name: "start_tzid", value: startTimeZone.identifier))
         }
 
         // If the end time zone is omitted and the start time zone is provided, the time zone of the end timestamp is the same as the start timestamp.
         if let endTimeZone {
-            tags.append(Tag(name: .unknown("end_tzid"), value: endTimeZone.identifier))
+            tags.append(Tag(name: "end_tzid", value: endTimeZone.identifier))
         }
 
         if let location {
-            tags.append(Tag(name: .unknown("location"), value: location))
+            tags.append(Tag(name: "location", value: location))
         }
 
         if let geohash {
-            tags.append(Tag(name: .unknown("g"), value: geohash))
+            tags.append(Tag(name: "g", value: geohash))
         }
 
         if let participants {
@@ -396,7 +396,7 @@ public extension EventCreating {
         }
 
         if let references {
-            tags += references.map { Tag(name: .unknown("r"), value: $0.absoluteString) }
+            tags += references.map { Tag(name: .webURL, value: $0.absoluteString) }
         }
 
         return try TimeBasedCalendarEvent(content: description, tags: tags, signedBy: keypair)

--- a/Sources/NostrSDK/Events/Calendars/CalendarEventInterpreting.swift
+++ b/Sources/NostrSDK/Events/Calendars/CalendarEventInterpreting.swift
@@ -11,21 +11,21 @@ public protocol CalendarEventInterpreting: NostrEvent, CalendarEventParticipantI
 public extension CalendarEventInterpreting {
     /// Universally unique identifier (UUID).
     var uuid: String? {
-        tags.first { $0.name.rawValue == "d" }?.value
+        tags.first { $0.name == TagName.identifier.rawValue }?.value
     }
 
     /// The name of the calendar event.
     var name: String? {
-        tags.first { $0.name.rawValue == "name" }?.value
+        tags.first { $0.name == "name" }?.value
     }
 
     /// The location of the calendar event. e.g. address, GPS coordinates, meeting room name, link to video call.
     var location: String? {
-        tags.first { $0.name.rawValue == "location" }?.value
+        tags.first { $0.name == "location" }?.value
     }
 
     /// The [geohash](https://en.wikipedia.org/wiki/Geohash) to associate calendar event with a searchable physical location.
     var geohash: String? {
-        tags.first { $0.name.rawValue == "g" }?.value
+        tags.first { $0.name == "g" }?.value
     }
 }

--- a/Sources/NostrSDK/Events/Calendars/CalendarEventParticipant.swift
+++ b/Sources/NostrSDK/Events/Calendars/CalendarEventParticipant.swift
@@ -49,7 +49,7 @@ public struct CalendarEventParticipant: PubkeyProviding, RelayProviding, Equatab
     /// Initializes a calendar event participant from a ``Tag``.
     /// `nil` is returned if the tag is not a pubkey tag.
     public init?(pubkeyTag: Tag) {
-        guard pubkeyTag.name == .pubkey else {
+        guard pubkeyTag.name == TagName.pubkey.rawValue else {
             return nil
         }
 
@@ -75,6 +75,6 @@ public struct CalendarEventParticipant: PubkeyProviding, RelayProviding, Equatab
 public protocol CalendarEventParticipantInterpreting: NostrEvent {}
 public extension CalendarEventParticipantInterpreting {
     var participants: [CalendarEventParticipant] {
-        tags.filter { $0.name == .pubkey }.compactMap { CalendarEventParticipant(pubkeyTag: $0) }
+        tags.filter { $0.name == TagName.pubkey.rawValue }.compactMap { CalendarEventParticipant(pubkeyTag: $0) }
     }
 }

--- a/Sources/NostrSDK/Events/Calendars/DateBasedCalendarEvent.swift
+++ b/Sources/NostrSDK/Events/Calendars/DateBasedCalendarEvent.swift
@@ -28,7 +28,7 @@ public final class DateBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// Start date is represented by ``TimeOmittedDate``.
     /// `nil` is returned if the backing `start` tag is malformed.
     public var startDate: TimeOmittedDate? {
-        guard let startString = tags.first(where: { $0.name.rawValue == "start" })?.value else {
+        guard let startString = tags.first(where: { $0.name == "start" })?.value else {
             return nil
         }
 
@@ -39,7 +39,7 @@ public final class DateBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// End date represented by ``TimeOmittedDate``.
     /// `nil` is returned if the backing `end` tag is malformed or if the calendar event ends on the same date as start.
     public var endDate: TimeOmittedDate? {
-        guard let endString = tags.first(where: { $0.name.rawValue == "end" })?.value else {
+        guard let endString = tags.first(where: { $0.name == "end" })?.value else {
             return nil
         }
 

--- a/Sources/NostrSDK/Events/Calendars/TimeBasedCalendarEvent.swift
+++ b/Sources/NostrSDK/Events/Calendars/TimeBasedCalendarEvent.swift
@@ -26,7 +26,7 @@ public final class TimeBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// The start timestamp is represented by ``Date``.
     /// `nil` is returned if the backing `start` tag is malformed.
     public var startTimestamp: Date? {
-        guard let startString = tags.first(where: { $0.name.rawValue == "start" })?.value, let startSeconds = Int(startString) else {
+        guard let startString = tags.first(where: { $0.name == "start" })?.value, let startSeconds = Int(startString) else {
             return nil
         }
 
@@ -37,7 +37,7 @@ public final class TimeBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// End timestamp represented by ``Date``.
     /// `nil` is returned if the backing `end` tag is malformed or if the calendar event ends instanteously.
     public var endTimestamp: Date? {
-        guard let endString = tags.first(where: { $0.name.rawValue == "end" })?.value, let endSeconds = Int(endString) else {
+        guard let endString = tags.first(where: { $0.name == "end" })?.value, let endSeconds = Int(endString) else {
             return nil
         }
 
@@ -46,7 +46,7 @@ public final class TimeBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
 
     /// The time zone of the start timestamp.
     public var startTimeZone: TimeZone? {
-        guard let timeZoneIdentifier = tags.first(where: { $0.name.rawValue == "start_tzid" })?.value else {
+        guard let timeZoneIdentifier = tags.first(where: { $0.name == "start_tzid" })?.value else {
             return nil
         }
 
@@ -56,7 +56,7 @@ public final class TimeBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// The time zone of the end timestamp.
     /// `nil` can be returned if the time zone identifier is malformed or if the time zone of the end timestamp is the same as the start timestamp.
     public var endTimeZone: TimeZone? {
-        guard let timeZoneIdentifier = tags.first(where: { $0.name.rawValue == "end_tzid" })?.value else {
+        guard let timeZoneIdentifier = tags.first(where: { $0.name == "end_tzid" })?.value else {
             return nil
         }
 

--- a/Sources/NostrSDK/Events/ContactListEvent.swift
+++ b/Sources/NostrSDK/Events/ContactListEvent.swift
@@ -47,12 +47,12 @@ public final class ContactListEvent: NostrEvent {
     
     /// Pubkeys for followed/known profiles.
     public var contactPubkeys: [String] {
-        tags.filter({ $0.name == .pubkey }).map { $0.value }
+        tags.filter({ $0.name == TagName.pubkey.rawValue }).map { $0.value }
     }
     
     /// Pubkey tags for followed/known profiles.
     public var contactPubkeyTags: [Tag] {
-        tags.filter({ $0.name == .pubkey })
+        tags.filter({ $0.name == TagName.pubkey.rawValue })
     }
     
     /// Relays the user knows about.

--- a/Sources/NostrSDK/Events/DeletionEvent.swift
+++ b/Sources/NostrSDK/Events/DeletionEvent.swift
@@ -33,6 +33,6 @@ public final class DeletionEvent: NostrEvent {
     
     /// The event ids that the creator requests deletion for.
     public var deletedEventIds: [String] {
-        tags.filter { $0.name == .event }.map { $0.value }
+        tags.filter { $0.name == TagName.event.rawValue }.map { $0.value }
     }
 }

--- a/Sources/NostrSDK/Events/DirectMessageEvent.swift
+++ b/Sources/NostrSDK/Events/DirectMessageEvent.swift
@@ -28,7 +28,7 @@ public final class DirectMessageEvent: NostrEvent, DirectMessageEncrypting {
     /// Returns decrypted content from Event given a `privateKey`
     public func decryptedContent(using privateKey: PrivateKey) throws -> String {
         let recipient = tags.first { tag in
-            tag.name == .pubkey
+            tag.name == TagName.pubkey.rawValue
         }
 
         guard let recipientPublicKeyHex = recipient?.value, let recipientPublicKey = PublicKey(hex: recipientPublicKeyHex) else {

--- a/Sources/NostrSDK/Events/GenericRepostEvent.swift
+++ b/Sources/NostrSDK/Events/GenericRepostEvent.swift
@@ -31,7 +31,7 @@ public class GenericRepostEvent: NostrEvent {
     
     /// The pubkey of the reposted event.
     var repostedEventPubkey: String? {
-        tags.first(where: { $0.name == .pubkey })?.value
+        tags.first(where: { $0.name == TagName.pubkey.rawValue })?.value
     }
     
     /// The note that is being reposted.
@@ -45,11 +45,11 @@ public class GenericRepostEvent: NostrEvent {
     
     /// The id of the event that is being reposted.
     var repostedEventId: String? {
-        tags.first(where: { $0.name == .event })?.value
+        tags.first(where: { $0.name == TagName.event.rawValue })?.value
     }
     
     /// The relay URL at which to fetch the reposted event.
     var repostedEventRelayURL: String? {
-        tags.first(where: { $0.name == .event })?.otherParameters.first
+        tags.first(where: { $0.name == TagName.event.rawValue })?.otherParameters.first
     }
 }

--- a/Sources/NostrSDK/Events/LongformContentEvent.swift
+++ b/Sources/NostrSDK/Events/LongformContentEvent.swift
@@ -14,7 +14,7 @@ import Foundation
 ///              * MUST NOT support adding HTML to Markdown.
 ///
 /// > Note: [NIP-23 Specification](https://github.com/nostr-protocol/nips/blob/master/23.md)
-public final class LongformContentEvent: NostrEvent {
+public final class LongformContentEvent: NostrEvent, HashtagInterpreting {
     public required init(from decoder: Decoder) throws {
         try super.init(from: decoder)
     }
@@ -30,7 +30,7 @@ public final class LongformContentEvent: NostrEvent {
     
     /// The date of the first time the article was published.
     var publishedAt: Date? {
-        guard let unixTimeString = tags.first(where: { $0.name == .publishedAt })?.value,
+        guard let unixTimeString = tags.first(where: { $0.name == TagName.publishedAt.rawValue })?.value,
               let unixSeconds = TimeInterval(unixTimeString) else {
             return nil
         }
@@ -39,29 +39,24 @@ public final class LongformContentEvent: NostrEvent {
     
     /// A unique identifier for the content. Can be reused in the future for replacing the event.
     var identifier: String? {
-        tags.first(where: { $0.name == .identifier})?.value
+        tags.first(where: { $0.name == TagName.identifier.rawValue })?.value
     }
     
     /// The article title.
     var title: String? {
-        tags.first(where: { $0.name == .title })?.value
+        tags.first(where: { $0.name == TagName.title.rawValue })?.value
     }
     
     /// A summary of the content.
     var summary: String? {
-        tags.first(where: { $0.name == .summary })?.value
+        tags.first(where: { $0.name == TagName.summary.rawValue })?.value
     }
     
     /// A URL pointing to an image to be shown along with the title.
     var imageURL: URL? {
-        guard let imageURLString = tags.first(where: { $0.name == .image })?.value else {
+        guard let imageURLString = tags.first(where: { $0.name == TagName.image.rawValue })?.value else {
             return nil
         }
         return URL(string: imageURLString)
-    }
-    
-    /// An list of topics about which the event might be of relevance.
-    var hashtags: [String] {
-        tags.filter { $0.name == .hashtag }.map { $0.value }
     }
 }

--- a/Sources/NostrSDK/Events/ReactionEvent.swift
+++ b/Sources/NostrSDK/Events/ReactionEvent.swift
@@ -26,10 +26,10 @@ public class ReactionEvent: NostrEvent, CustomEmojiInterpreting {
     }
     
     public var reactedEventId: String? {
-        tags.last(where: { $0.name == .event })?.value
+        tags.last(where: { $0.name == TagName.event.rawValue })?.value
     }
 
     public var reactedEventPubkey: String? {
-        tags.last(where: { $0.name == .pubkey })?.value
+        tags.last(where: { $0.name == TagName.pubkey.rawValue })?.value
     }
 }

--- a/Sources/NostrSDK/Events/ReportEvent.swift
+++ b/Sources/NostrSDK/Events/ReportEvent.swift
@@ -45,7 +45,7 @@ public final class ReportEvent: NostrEvent {
     
     /// The reason that the event or user was reported.
     public var reportType: ReportType? {
-        guard let tag = tags.first(where: { $0.name == .event }) ?? tags.first(where: { $0.name == .pubkey }),
+        guard let tag = tags.first(where: { $0.name == TagName.event.rawValue }) ?? tags.first(where: { $0.name == TagName.pubkey.rawValue }),
               let reportString = tag.otherParameters.first else {
             return nil
         }

--- a/Sources/NostrSDK/Events/Tags/HashtagInterpreting.swift
+++ b/Sources/NostrSDK/Events/Tags/HashtagInterpreting.swift
@@ -12,7 +12,7 @@ public protocol HashtagInterpreting: NostrEvent {}
 public extension HashtagInterpreting {
     /// The hashtags of the event.
     var hashtags: [String] {
-        tags.filter { $0.name == .hashtag }
+        tags.filter { $0.name == TagName.hashtag.rawValue }
             .map { $0.value }
     }
 }

--- a/Sources/NostrSDK/Events/Tags/ReferenceTagInterpreting.swift
+++ b/Sources/NostrSDK/Events/Tags/ReferenceTagInterpreting.swift
@@ -12,7 +12,7 @@ public protocol ReferenceTagInterpreting: NostrEvent {}
 public extension ReferenceTagInterpreting {
     /// The reference URLs of the event.
     var references: [URL] {
-        tags.filter { $0.name.rawValue == "r" }
+        tags.filter { $0.name == TagName.webURL.rawValue }
             .compactMap { URL(string: $0.value) }
     }
 }

--- a/Sources/NostrSDK/Events/TextNoteEvent.swift
+++ b/Sources/NostrSDK/Events/TextNoteEvent.swift
@@ -27,13 +27,13 @@ public final class TextNoteEvent: NostrEvent, CustomEmojiInterpreting {
     
     /// Pubkeys mentioned in the note content.
     public var mentionedPubkeys: [String] {
-        let pubkeyTags = tags.filter { $0.name == .pubkey }
+        let pubkeyTags = tags.filter { $0.name == TagName.pubkey.rawValue }
         return pubkeyTags.map { $0.value }
     }
     
     /// Events mentioned in the note content.
     public var mentionedEventIds: [String] {
-        let eventTags = tags.filter { $0.name == .event }
+        let eventTags = tags.filter { $0.name == TagName.event.rawValue }
         return eventTags.map { $0.value }
     }
     
@@ -41,6 +41,6 @@ public final class TextNoteEvent: NostrEvent, CustomEmojiInterpreting {
     ///
     /// See [NIP-14 - Subject tag in Text events](https://github.com/nostr-protocol/nips/blob/master/14.md).
     public var subject: String? {
-        tags.first(where: { $0.name == .subject })?.value
+        tags.first(where: { $0.name == TagName.subject.rawValue })?.value
     }
 }


### PR DESCRIPTION
There isn't a one-to-one mapping. For example, the "r" tag can have multiple meanings and semantics. So it makes sense to be able to map a tag name enum to the actual string representation, but not in the other direction.