### PR TITLE
minor further improvements to tags

### DIFF
--- a/Sources/NostrSDK/Events/Calendars/DateBasedCalendarEvent.swift
+++ b/Sources/NostrSDK/Events/Calendars/DateBasedCalendarEvent.swift
@@ -28,7 +28,7 @@ public final class DateBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// Start date is represented by ``TimeOmittedDate``.
     /// `nil` is returned if the backing `start` tag is malformed.
     public var startDate: TimeOmittedDate? {
-        guard let startString = tags.first(where: { $0.name == "start" })?.value else {
+        guard let startString = valueForRawTagName("start") else {
             return nil
         }
 
@@ -39,7 +39,7 @@ public final class DateBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// End date represented by ``TimeOmittedDate``.
     /// `nil` is returned if the backing `end` tag is malformed or if the calendar event ends on the same date as start.
     public var endDate: TimeOmittedDate? {
-        guard let endString = tags.first(where: { $0.name == "end" })?.value else {
+        guard let endString = valueForRawTagName("end") else {
             return nil
         }
 

--- a/Sources/NostrSDK/Events/Calendars/TimeBasedCalendarEvent.swift
+++ b/Sources/NostrSDK/Events/Calendars/TimeBasedCalendarEvent.swift
@@ -26,7 +26,7 @@ public final class TimeBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// The start timestamp is represented by ``Date``.
     /// `nil` is returned if the backing `start` tag is malformed.
     public var startTimestamp: Date? {
-        guard let startString = tags.first(where: { $0.name == "start" })?.value, let startSeconds = Int(startString) else {
+        guard let startString = valueForRawTagName("start"), let startSeconds = Int(startString) else {
             return nil
         }
 
@@ -37,7 +37,7 @@ public final class TimeBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// End timestamp represented by ``Date``.
     /// `nil` is returned if the backing `end` tag is malformed or if the calendar event ends instanteously.
     public var endTimestamp: Date? {
-        guard let endString = tags.first(where: { $0.name == "end" })?.value, let endSeconds = Int(endString) else {
+        guard let endString = valueForRawTagName("end"), let endSeconds = Int(endString) else {
             return nil
         }
 
@@ -46,7 +46,7 @@ public final class TimeBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
 
     /// The time zone of the start timestamp.
     public var startTimeZone: TimeZone? {
-        guard let timeZoneIdentifier = tags.first(where: { $0.name == "start_tzid" })?.value else {
+        guard let timeZoneIdentifier = valueForRawTagName("start_tzid") else {
             return nil
         }
 
@@ -56,7 +56,7 @@ public final class TimeBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// The time zone of the end timestamp.
     /// `nil` can be returned if the time zone identifier is malformed or if the time zone of the end timestamp is the same as the start timestamp.
     public var endTimeZone: TimeZone? {
-        guard let timeZoneIdentifier = tags.first(where: { $0.name == "end_tzid" })?.value else {
+        guard let timeZoneIdentifier = valueForRawTagName("end_tzid") else {
             return nil
         }
 

--- a/Sources/NostrSDK/Events/GenericRepostEvent.swift
+++ b/Sources/NostrSDK/Events/GenericRepostEvent.swift
@@ -31,7 +31,7 @@ public class GenericRepostEvent: NostrEvent {
     
     /// The pubkey of the reposted event.
     var repostedEventPubkey: String? {
-        tags.first(where: { $0.name == TagName.pubkey.rawValue })?.value
+        valueForTagName(.pubkey)
     }
     
     /// The note that is being reposted.
@@ -45,7 +45,7 @@ public class GenericRepostEvent: NostrEvent {
     
     /// The id of the event that is being reposted.
     var repostedEventId: String? {
-        tags.first(where: { $0.name == TagName.event.rawValue })?.value
+        valueForTagName(.event)
     }
     
     /// The relay URL at which to fetch the reposted event.

--- a/Sources/NostrSDK/Events/LongformContentEvent.swift
+++ b/Sources/NostrSDK/Events/LongformContentEvent.swift
@@ -30,7 +30,7 @@ public final class LongformContentEvent: NostrEvent, HashtagInterpreting {
     
     /// The date of the first time the article was published.
     var publishedAt: Date? {
-        guard let unixTimeString = tags.first(where: { $0.name == TagName.publishedAt.rawValue })?.value,
+        guard let unixTimeString = valueForTagName(.publishedAt),
               let unixSeconds = TimeInterval(unixTimeString) else {
             return nil
         }
@@ -39,22 +39,22 @@ public final class LongformContentEvent: NostrEvent, HashtagInterpreting {
     
     /// A unique identifier for the content. Can be reused in the future for replacing the event.
     var identifier: String? {
-        tags.first(where: { $0.name == TagName.identifier.rawValue })?.value
+        valueForTagName(.identifier)
     }
     
     /// The article title.
     var title: String? {
-        tags.first(where: { $0.name == TagName.title.rawValue })?.value
+        valueForTagName(.title)
     }
     
     /// A summary of the content.
     var summary: String? {
-        tags.first(where: { $0.name == TagName.summary.rawValue })?.value
+        valueForTagName(.summary)
     }
     
     /// A URL pointing to an image to be shown along with the title.
     var imageURL: URL? {
-        guard let imageURLString = tags.first(where: { $0.name == TagName.image.rawValue })?.value else {
+        guard let imageURLString = valueForTagName(.image) else {
             return nil
         }
         return URL(string: imageURLString)

--- a/Sources/NostrSDK/Events/NostrEvent.swift
+++ b/Sources/NostrSDK/Events/NostrEvent.swift
@@ -89,4 +89,14 @@ public class NostrEvent: Codable {
                                            tags: tags,
                                            content: content)
     }
+    
+    /// the String value for the provided ``TagName``, if it exists
+    public func valueForTagName(_ tag: TagName) -> String? {
+        valueForRawTagName(tag.rawValue)
+    }
+    
+    /// the String value for the provided raw tag name, if it exists
+    public func valueForRawTagName(_ tagName: String) -> String? {
+        tags.first(where: { $0.name == tagName })?.value
+    }
 }

--- a/Sources/NostrSDK/Tag.swift
+++ b/Sources/NostrSDK/Tag.swift
@@ -8,28 +8,28 @@
 import Foundation
 
 /// A constant that describes the type of a ``Tag``.
-public enum TagName {
+public enum TagName: String {
     
     /// a custom emoji that defines the shortcode name and image URL of the image file
     case emoji
     
     /// points to the id of an event this event is quoting, replying to or referring to somehow
-    case event
+    case event = "e"
     
     /// a hashtag to categorize events for easy searching
-    case hashtag
+    case hashtag = "t"
     
     /// points to a pubkey of someone that is referred to in the event
-    case pubkey
+    case pubkey = "p"
     
-    case publishedAt
+    case publishedAt = "published_at"
     
-    case identifier
+    case identifier = "d"
     
     case image
     
     /// a stringified kind number
-    case kind
+    case kind = "k"
     
     /// a short subject for a text note, similar to subjects in emails
     case subject
@@ -40,36 +40,7 @@ public enum TagName {
     case title
     
     /// a web URL the event is referring to in some way. See [NIP-24 - Extra metadata fields and tags](https://github.com/nostr-protocol/nips/blob/master/24.md#tags).
-    case webURL
-    
-    var rawValue: String {
-        switch self {
-        case .emoji:
-            return "emoji"
-        case .event:
-            return "e"
-        case .hashtag:
-            return "t"
-        case .pubkey:
-            return "p"
-        case .publishedAt:
-            return "published_at"
-        case .identifier:
-            return "d"
-        case .image:
-            return "image"
-        case .kind:
-            return "k"
-        case .subject:
-            return "subject"
-        case .summary:
-            return "summary"
-        case .title:
-            return "title"
-        case .webURL:
-            return "r"
-        }
-    }
+    case webURL = "r"
 }
 
 /// A constant that describes a type of reference to an event.


### PR DESCRIPTION
This PR adds some minor further improvements to tags:

1. Shortcut functions that can be reused to grab the value of a specific `TagName` or raw tag name from an event.
2. Since we no longer need the `.unknown` case for `TagName`, we can simply make the enum `String`-based, providing raw values inline with the cases.