### PR TITLE
add support for Bech32-encoded, TLV-encoded identifiers (nprofile, nevent, nrelay, naddr)

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@ disabled_rules:
   - nesting
   - trailing_whitespace
   - type_body_length
+  - function_body_length
 
 excluded:
   - .build

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,12 +1,12 @@
 disabled_rules:
   - cyclomatic_complexity
   - file_length
+  - function_body_length
   - identifier_name
   - line_length
   - nesting
   - trailing_whitespace
   - type_body_length
-  - function_body_length
 
 excluded:
   - .build

--- a/Sources/NostrSDK/Bech32.swift
+++ b/Sources/NostrSDK/Bech32.swift
@@ -106,9 +106,10 @@ class Bech32 {
         guard let strBytes = str.data(using: .utf8) else {
             throw DecodingError.nonUTF8String
         }
-        guard strBytes.count <= 90 else {
-            throw DecodingError.stringLengthExceeded
-        }
+        // Montz: The length limit of 90 characters is for bitcoin and must be removed for Nostr identifiers, which can be longer.
+//        guard strBytes.count <= 90 else {
+//            throw DecodingError.stringLengthExceeded
+//        }
         var lower: Bool = false
         var upper: Bool = false
         for c in strBytes {

--- a/Sources/NostrSDK/Helpers/String+Additions.swift
+++ b/Sources/NostrSDK/Helpers/String+Additions.swift
@@ -31,4 +31,11 @@ public extension String {
 
         return data
     }
+    
+    func decoded(using encoding: String.Encoding = .utf8) -> String? {
+        guard let hexData = hexadecimalData else {
+            return nil
+        }
+        return String(data: hexData, encoding: encoding)
+    }
 }

--- a/Sources/NostrSDK/MetadataCoding.swift
+++ b/Sources/NostrSDK/MetadataCoding.swift
@@ -1,0 +1,262 @@
+//
+//  MetadataCoding.swift
+//
+//
+//  Created by Bryan Montz on 12/3/23.
+//
+
+import Foundation
+
+/// The type of Bech32-encoded identifier.
+/// These identifiers can be used to succinctly encapsulate metadata to aid in the discovery of events and users.
+/// See [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) for information about how these Bech32-encoded
+public enum Bech32IdentifierType: String {
+    case profile = "nprofile"
+    case event = "nevent"
+    case relay = "nrelay"
+    case address = "naddr"
+}
+
+/// An error encountered while encoding or decoding TLV (Type-Length-Value) data.
+public enum TLVCodingError: Error {
+    case unknownPrefix
+    case missingExpectedData
+    case malformedData
+    case failedToEncode
+}
+
+/// The components of the TLV-encoded (Type-Length-Value) data.
+private enum TLVEncodingType: Int {
+    case special, relay, author, kind
+    
+    var typeByte: String {
+        String(format: "%02x", rawValue)
+    }
+}
+
+/// A container for metadata about a user or event, for encoding and decoding to and from Bech32-encoded identifiers.
+public struct Metadata {
+    
+    /// A 32-byte hexadecimal public key.
+    var pubkey: String?
+    
+    /// One or more relays on which the user or event can be found.
+    var relays: [String]?
+    
+    /// A 32-byte hexadecimal event identifier.
+    var eventId: String?
+    
+    /// An identifier (d-tag) associated with an event, for use with parameterized replaceable events.
+    var identifier: String?
+    
+    /// The kind of the event, as an integer.
+    var kind: UInt32?
+}
+
+/// A protocol containing a set of functions for encoding and decoding identifiers.
+/// See [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) for the full specifications.
+public protocol MetadataCoding {}
+public extension MetadataCoding {
+    
+    /// Decodes the metadata contained in a Bech32-encoded identifier (e.g. nprofile, nevent, nrelay, naddr).
+    /// - Parameter identifier: The identifier to decode.
+    /// - Returns: The metadata decoded from the identifier.
+    ///
+    /// Throws an error if the hrp (human-readable part) of the identifier is unknown or if the data is missing or malformed.
+    func decodedMetadata(from identifier: String) throws -> Metadata {
+        let (hrp, checksum) = try Bech32.decode(identifier)
+        guard let identifierType = Bech32IdentifierType(rawValue: hrp) else {
+            throw TLVCodingError.unknownPrefix
+        }
+        
+        guard let tlvString = checksum.base8FromBase5?.hexString else {
+            throw TLVCodingError.missingExpectedData
+        }
+        
+        return try decodedTLVString(tlvString, identifierType: identifierType)
+    }
+    
+    /// Decodes the metadata contained in a TLV-encoded string.
+    /// - Parameters:
+    ///   - tlvString: The TLV-encoded string.
+    ///   - identifierType: The identifier type to decode.
+    /// - Returns: The metadata decoded from the identifier.
+    ///
+    /// > Note: This function is provided for debugging and testing, as it is an intermediate result.
+    func decodedTLVString(_ tlvString: String, identifierType: Bech32IdentifierType) throws -> Metadata {
+        var pubkey: String?
+        var relays = [String]()
+        var eventId: String?
+        var identifier: String?
+        var kind: UInt32?
+        
+        var scanner = tlvString[...]
+        while !scanner.isEmpty {
+            let typeByte = scanner.readAndDropFirst(2)
+            let lengthByte = scanner.readAndDropFirst(2)
+            guard let lengthInBytes = Int(lengthByte, radix: 16) else {
+                throw TLVCodingError.malformedData
+            }
+            
+            let contentBytes = scanner.readAndDropFirst(lengthInBytes * 2)  // 2 chars per byte
+            
+            guard let typeInt = Int(typeByte),
+                  let contentType = TLVEncodingType(rawValue: typeInt) else {
+                // unrecognized type, NIP-19 says to ignore rather than fail here
+                continue
+            }
+            
+            let content = String(contentBytes)
+            switch contentType {
+            case .special:
+                switch identifierType {
+                case .profile:
+                    pubkey = content
+                case .event:
+                    eventId = content
+                case .relay:
+                    if let decoded = content.decoded(using: .ascii) {
+                        relays.append(decoded)
+                    }
+                case .address:
+                    if let decoded = content.decoded() {
+                        identifier = decoded
+                    }
+                }
+            case .relay:
+                if let decoded = content.decoded(using: .ascii) {
+                    relays.append(decoded)
+                }
+            case .author:
+                pubkey = content
+            case .kind:
+                if let kindInt = UInt32(content, radix: 16) {
+                    kind = kindInt
+                }
+            }
+        }
+        
+        return Metadata(pubkey: pubkey,
+                        relays: relays,
+                        eventId: eventId,
+                        identifier: identifier,
+                        kind: kind)
+    }
+    
+    /// The Bech32-encoded, TLV-encoded identifier based on the specified type and metadata.
+    /// - Parameters:
+    ///   - metadata: The metadata to encode.
+    ///   - identifierType: The identifier type to encode to.
+    /// - Returns: The requested identifier.
+    func encodedIdentifier(with metadata: Metadata, identifierType: Bech32IdentifierType) throws -> String {
+        let tlvEncoded = try tlvEncodedString(with: metadata, identifierType: identifierType)
+        guard let encoded = Bech32.encode(identifierType.rawValue, hex: tlvEncoded) else {
+            throw TLVCodingError.failedToEncode
+        }
+        return encoded
+    }
+    
+    /// The TLV-encoded (Type-Length-Value) string based on the specified type and metadata.
+    /// - Parameters:
+    ///   - metadata: The metadata to encode.
+    ///   - identifierType: The identifier type to encode to.
+    /// - Returns: The TLV-encoded String.
+    ///
+    /// Throws an error if the metadata does not contain the required information to create the requested identifier.
+    ///
+    /// > Note: This function is provided for debugging and testing, as it is an intermediate result and must be Bech32-encoded before transmitting.
+    func tlvEncodedString(with metadata: Metadata, identifierType: Bech32IdentifierType) throws -> String {
+        var contents = ""
+        
+        let specialTypeValue: Data?
+        switch identifierType {
+        case .profile:
+            guard let pubkey = metadata.pubkey else {
+                throw TLVCodingError.missingExpectedData
+            }
+            specialTypeValue = pubkey.hexadecimalData
+        case .event:
+            guard let eventId = metadata.eventId else {
+                throw TLVCodingError.missingExpectedData
+            }
+            specialTypeValue = eventId.hexadecimalData
+        case .relay:
+            guard let relay = metadata.relays?.first else {
+                throw TLVCodingError.missingExpectedData
+            }
+            specialTypeValue = relay.data(using: .ascii)
+        case .address:
+            specialTypeValue = metadata.identifier?.data(using: .utf8)
+        }
+        
+        if let lengthByte = (specialTypeValue ?? Data()).byteLengthString {
+            contents.append(TLVEncodingType.special.typeByte)
+            contents.append(lengthByte)
+            contents.append(specialTypeValue?.hexString ?? "")
+        }
+        
+        // relays
+        if identifierType != .relay, let relays = metadata.relays {
+            for relay in relays where !relay.isEmpty {
+                let relayData = relay.data(using: .ascii)
+                if let lengthByte = (relayData ?? Data()).byteLengthString {
+                    contents.append(TLVEncodingType.relay.typeByte)
+                    contents.append(lengthByte)
+                    contents.append(relayData?.hexString ?? "")
+                }
+            }
+        }
+        
+        if identifierType == .address || identifierType == .event {
+            // author
+            if let pubkey = metadata.pubkey, let lengthByte = pubkey.hexadecimalData?.byteLengthString {
+                contents.append(TLVEncodingType.author.typeByte)
+                contents.append(lengthByte)
+                contents.append(pubkey)
+            }
+            
+            // kind
+            if let kind = metadata.kind {
+                var bigEndianData = Data()
+                withUnsafeBytes(of: kind.bigEndian) { bigEndianData.append(contentsOf: $0) }
+                if let lengthByte = bigEndianData.byteLengthString {
+                    contents.append(TLVEncodingType.kind.typeByte)
+                    contents.append(lengthByte)
+                    contents.append(bigEndianData.hexString)
+                }
+            }
+        }
+        
+        return contents
+    }
+}
+
+fileprivate extension Data {
+    
+    /// The length of the Data in a one-byte hexadecimal string.
+    ///
+    /// For example, for a Data with 32 bytes, the result will be "20".
+    var byteLengthString: String? {
+        // Ensure the length is representable by a byte (0 to 255)
+        guard count >= 0 && count <= 255 else {
+            return nil // Length exceeds one byte
+        }
+
+        // Format the length as a two-character hexadecimal string
+        return String(format: "%02x", count)
+    }
+}
+
+fileprivate extension Substring {
+    
+    /// Extracts the leading characters in a String.
+    /// - Parameter numberOfCharacters: The number of characters to read.
+    /// - Returns: The extracted characters.
+    ///
+    /// > Note: This function mutates the string by removing the leading characters from it.
+    mutating func readAndDropFirst(_ numberOfCharacters: Int = 1) -> Substring {
+        let result = prefix(numberOfCharacters)
+        self = dropFirst(numberOfCharacters)
+        return result
+    }
+}

--- a/Tests/NostrSDKTests/Bech32Tests.swift
+++ b/Tests/NostrSDKTests/Bech32Tests.swift
@@ -22,6 +22,9 @@ class Bech32Tests: XCTestCase {
     private let _validChecksum: [String] = [
         "A12UEL5L",
         "an83characterlonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1tt5tgs",
+        // Montz: The length limit of 90 characters is for bitcoin and must be removed for Nostr identifiers, which can be longer. Therefore this test case was moved from invalid to valid.
+        "an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx",
+        /////////
         "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw",
         "11qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j",
         "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w",
@@ -31,8 +34,6 @@ class Bech32Tests: XCTestCase {
     private let _invalidChecksum: [InvalidChecksum] = [
         (" 1nwldj5", Bech32.DecodingError.nonPrintableCharacter),
         ("\u{7f}1axkwrx", Bech32.DecodingError.nonPrintableCharacter),
-        // Montz: The length limit of 90 characters is for bitcoin and must be removed for Nostr identifiers, which can be longer.
-//        ("an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx", Bech32.DecodingError.stringLengthExceeded),
         ("pzry9x0s0muk", Bech32.DecodingError.noChecksumMarker),
         ("1pzry9x0s0muk", Bech32.DecodingError.incorrectHrpSize),
         ("x1b4n0q5v", Bech32.DecodingError.invalidCharacter),

--- a/Tests/NostrSDKTests/Bech32Tests.swift
+++ b/Tests/NostrSDKTests/Bech32Tests.swift
@@ -31,7 +31,8 @@ class Bech32Tests: XCTestCase {
     private let _invalidChecksum: [InvalidChecksum] = [
         (" 1nwldj5", Bech32.DecodingError.nonPrintableCharacter),
         ("\u{7f}1axkwrx", Bech32.DecodingError.nonPrintableCharacter),
-        ("an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx", Bech32.DecodingError.stringLengthExceeded),
+        // Montz: The length limit of 90 characters is for bitcoin and must be removed for Nostr identifiers, which can be longer.
+//        ("an84characterslonghumanreadablepartthatcontainsthenumber1andtheexcludedcharactersbio1569pvx", Bech32.DecodingError.stringLengthExceeded),
         ("pzry9x0s0muk", Bech32.DecodingError.noChecksumMarker),
         ("1pzry9x0s0muk", Bech32.DecodingError.incorrectHrpSize),
         ("x1b4n0q5v", Bech32.DecodingError.invalidCharacter),

--- a/Tests/NostrSDKTests/MetadataCodingTests.swift
+++ b/Tests/NostrSDKTests/MetadataCodingTests.swift
@@ -1,0 +1,155 @@
+//
+//  MetadataCodingTests.swift
+//
+//
+//  Created by Bryan Montz on 12/5/23.
+//
+
+import XCTest
+@testable import NostrSDK
+
+class MetadataCodingTests: XCTestCase, MetadataCoding {
+    
+    // MARK: - Decoding
+    
+    func testNprofileDecoding() throws {
+        let input = "nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p"
+        let (hrp, _) = try Bech32.decode(input)
+        XCTAssertEqual(hrp, "nprofile")
+        
+        let result = try decodedMetadata(from: input)
+        
+        XCTAssertEqual(result.pubkey, "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d")
+        
+        let expectedRelays = [
+            "wss://r.x.com",
+            "wss://djbas.sadkb.com"
+        ]
+        XCTAssertEqual(result.relays, expectedRelays)
+    }
+    
+    func testNeventDecoding() throws {
+        let input = "nevent1qqstna2yrezu5wghjvswqqculvvwxsrcvu7uc0f78gan4xqhvz49d9spr3mhxue69uhkummnw3ez6un9d3shjtn4de6x2argwghx6egpr4mhxue69uhkummnw3ez6ur4vgh8wetvd3hhyer9wghxuet5nxnepm"
+        let (hrp, _) = try Bech32.decode(input)
+        XCTAssertEqual(hrp, "nevent")
+        
+        let result = try decodedMetadata(from: input)
+        XCTAssertEqual(result.eventId, "b9f5441e45ca39179320e0031cfb18e34078673dcc3d3e3a3b3a981760aa5696")
+        
+        let expectedRelays = [
+            "wss://nostr-relay.untethr.me",
+            "wss://nostr-pub.wellorder.net"
+        ]
+        XCTAssertEqual(result.relays, expectedRelays)
+    }
+    
+    func testNrelayDecoding() throws {
+        let id = "nrelay1qqt8wumn8ghj7un9d3shjtnwdaehgu3wvfskueq4r295t"
+        let (hrp, _) = try Bech32.decode(id)
+        XCTAssertEqual(hrp, "nrelay")
+        
+        let metadata = try decodedMetadata(from: id)
+        
+        XCTAssertEqual(metadata.relays, ["wss://relay.nostr.band"])
+    }
+    
+    func testNaddrDecoding() throws {
+        let id = "naddr1qqxnzdesxqmnxvpexqunzvpcqyt8wumn8ghj7un9d3shjtnwdaehgu3wvfskueqzypve7elhmamff3sr5mgxxms4a0rppkmhmn7504h96pfcdkpplvl2jqcyqqq823cnmhuld"
+        let (hrp, _) = try Bech32.decode(id)
+        XCTAssertEqual(hrp, "naddr")
+        
+        let metadata = try decodedMetadata(from: id)
+        
+        XCTAssertEqual(metadata.pubkey, "599f67f7df7694c603a6d0636e15ebc610db77dcfd47d6e5d05386d821fb3ea9")
+        XCTAssertEqual(metadata.relays, ["wss://relay.nostr.band"])
+        XCTAssertNil(metadata.eventId)
+        XCTAssertEqual(metadata.identifier, "1700730909108")
+        XCTAssertEqual(metadata.kind, 30023)
+    }
+    
+    func testIgnoreUnrecognizedType() throws {
+        // start with the pubkey (type is "00", length is "20", the rest is the pubkey)
+        var tlvString = "00203bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"
+        
+        // append unrecognized TLV type (04)
+        tlvString += "04080000000000000000"
+        
+        // append relay TLV (type is "01", length is "03", the rest is the relay in ASCII)
+        tlvString += "010d7773733a2f2f722e782e636f6d"
+        
+        // make sure we can drop the unrecognized type and still get the relay after it
+        
+        let metadata = try decodedTLVString(tlvString, identifierType: .profile)
+        
+        XCTAssertEqual(metadata.pubkey, "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d")
+        XCTAssertEqual(metadata.relays, ["wss://r.x.com"])
+    }
+    
+    // MARK: - Encoding
+    
+    func testRawTLVEncoding() throws {
+        var metadata = Metadata()
+        metadata.pubkey = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"
+        
+        metadata.relays = [
+            "wss://r.x.com",
+            "wss://djbas.sadkb.com"
+        ]
+        
+        let encoded = try tlvEncodedString(with: metadata, identifierType: .profile)
+        
+        var expectedTLVEncodedString = ""
+        expectedTLVEncodedString.append("00203bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d") // pubkey
+        expectedTLVEncodedString.append("010d7773733a2f2f722e782e636f6d") // relay 1
+        expectedTLVEncodedString.append("01157773733a2f2f646a6261732e7361646b622e636f6d") // relay 2
+        
+        XCTAssertEqual(encoded, expectedTLVEncodedString)
+    }
+    
+    func testNprofileEncoding() throws {
+        var metadata = Metadata()
+        metadata.pubkey = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"
+        
+        metadata.relays = [
+            "wss://r.x.com",
+            "wss://djbas.sadkb.com"
+        ]
+        
+        let identifier = try encodedIdentifier(with: metadata, identifierType: .profile)
+        XCTAssertEqual(identifier, "nprofile1qqsrhuxx8l9ex335q7he0f09aej04zpazpl0ne2cgukyawd24mayt8gpp4mhxue69uhhytnc9e3k7mgpz4mhxue69uhkg6nzv9ejuumpv34kytnrdaksjlyr9p")
+    }
+    
+    func testNeventEncoding() throws {
+        var metadata = Metadata()
+        metadata.eventId = "b9f5441e45ca39179320e0031cfb18e34078673dcc3d3e3a3b3a981760aa5696"
+        metadata.relays = [
+            "wss://nostr-relay.untethr.me",
+            "wss://nostr-pub.wellorder.net"
+        ]
+        
+        let identifier = try encodedIdentifier(with: metadata, identifierType: .event)
+        let expected = "nevent1qqstna2yrezu5wghjvswqqculvvwxsrcvu7uc0f78gan4xqhvz49d9spr3mhxue69uhkummnw3ez6un9d3shjtn4de6x2argwghx6egpr4mhxue69uhkummnw3ez6ur4vgh8wetvd3hhyer9wghxuet5nxnepm"
+        XCTAssertEqual(identifier, expected)
+    }
+    
+    func testNrelayEncoding() throws {
+        var metadata = Metadata()
+        metadata.relays = ["wss://relay.nostr.band"]
+        
+        let identifier = try encodedIdentifier(with: metadata, identifierType: .relay)
+        let expected = "nrelay1qqt8wumn8ghj7un9d3shjtnwdaehgu3wvfskueq4r295t"
+        XCTAssertEqual(identifier, expected)
+    }
+    
+    func testNaddrEncoding() throws {
+        var metadata = Metadata()
+        metadata.pubkey = "599f67f7df7694c603a6d0636e15ebc610db77dcfd47d6e5d05386d821fb3ea9"
+        metadata.relays = ["wss://relay.nostr.band"]
+        metadata.identifier = "1700730909108"
+        metadata.kind = 30023
+        
+        let identifier = try encodedIdentifier(with: metadata, identifierType: .address)
+        let expected = "naddr1qqxnzdesxqmnxvpexqunzvpcqyt8wumn8ghj7un9d3shjtnwdaehgu3wvfskueqzypve7elhmamff3sr5mgxxms4a0rppkmhmn7504h96pfcdkpplvl2jqcyqqq823cnmhuld"
+        XCTAssertEqual(identifier, expected)
+    }
+}


### PR DESCRIPTION
See NIP-19:
https://github.com/nostr-protocol/nips/blob/master/19.md

Closes https://github.com/nostr-sdk/nostr-sdk-ios/issues/112