### PR TITLE
add support for NIP-51 mute lists

### DIFF
--- a/Sources/NostrSDK/EventCreating.swift
+++ b/Sources/NostrSDK/EventCreating.swift
@@ -229,23 +229,23 @@ public extension EventCreating {
     /// Creates a ``MuteListEvent`` (kind 10000) containing things the user doesn't want to see in their feeds. Mute list items be publicly visible or private.
     /// - Parameters:
     ///   - publiclyMutedPubkeys: Pubkeys to mute.
-    ///   - secretlyMutedPubkeys: Pubkeys to secretly mute.
+    ///   - privatelyMutedPubkeys: Pubkeys to secretly mute.
     ///   - publiclyMutedEventIds: Event ids to mute.
-    ///   - secretlyMutedEventIds: Event ids to secretly mute.
+    ///   - privatelyMutedEventIds: Event ids to secretly mute.
     ///   - publiclyMutedHashtags: Hashtags to mute.
-    ///   - secretlyMutedHashtags: Hashtags to secretly mute.
+    ///   - privatelyMutedHashtags: Hashtags to secretly mute.
     ///   - publiclyMutedKeywords: Keywords to mute.
-    ///   - secretlyMutedKeywords: Keywords to secretly mute.
+    ///   - privatelyMutedKeywords: Keywords to secretly mute.
     ///   - keypair: The Keypair to sign with.
     /// - Returns: The signed ``MuteListEvent``.
     func muteList(withPubliclyMutedPubkeys publiclyMutedPubkeys: [String] = [],
-                  secretlyMutedPubkeys: [String] = [],
+                  privatelyMutedPubkeys: [String] = [],
                   publiclyMutedEventIds: [String] = [],
-                  secretlyMutedEventIds: [String] = [],
+                  privatelyMutedEventIds: [String] = [],
                   publiclyMutedHashtags: [String] = [],
-                  secretlyMutedHashtags: [String] = [],
+                  privatelyMutedHashtags: [String] = [],
                   publiclyMutedKeywords: [String] = [],
-                  secretlyMutedKeywords: [String] = [],
+                  privatelyMutedKeywords: [String] = [],
                   signedBy keypair: Keypair) throws -> MuteListEvent {
         var publicTags = [Tag]()
         
@@ -263,16 +263,16 @@ public extension EventCreating {
         }
         
         var secretTags = [[String]]()
-        for pubkey in secretlyMutedPubkeys {
+        for pubkey in privatelyMutedPubkeys {
             secretTags.append([TagName.pubkey.rawValue, pubkey])
         }
-        for eventId in secretlyMutedEventIds {
+        for eventId in privatelyMutedEventIds {
             secretTags.append([TagName.event.rawValue, eventId])
         }
-        for hashtag in secretlyMutedHashtags {
+        for hashtag in privatelyMutedHashtags {
             secretTags.append([TagName.hashtag.rawValue, hashtag])
         }
-        for keyword in secretlyMutedKeywords {
+        for keyword in privatelyMutedKeywords {
             secretTags.append([TagName.word.rawValue, keyword])
         }
         

--- a/Sources/NostrSDK/EventKind.swift
+++ b/Sources/NostrSDK/EventKind.swift
@@ -68,6 +68,11 @@ public enum EventKind: RawRepresentable, CaseIterable, Codable, Equatable {
     /// See [NIP-56](https://github.com/nostr-protocol/nips/blob/b4cdc1a73d415c79c35655fa02f5e55cd1f2a60c/56.md#nip-56).
     case report
     
+    /// This kind of event contains a list of things the user does not want to see, such as pubkeys, hashtags, words, and event ids (threads).
+    ///
+    /// See [NIP-51](https://github.com/nostr-protocol/nips/blob/master/51.md#standard-lists)
+    case muteList
+    
     /// This kind of event is for long-form texxt content, generally referred to as "articles" or "blog posts".
     ///
     /// See [NIP-23](https://github.com/nostr-protocol/nips/blob/master/23.md).
@@ -96,6 +101,7 @@ public enum EventKind: RawRepresentable, CaseIterable, Codable, Equatable {
         .reaction,
         .genericRepost,
         .report,
+        .muteList,
         .longformContent,
         .dateBasedCalendarEvent,
         .timeBasedCalendarEvent
@@ -118,6 +124,7 @@ public enum EventKind: RawRepresentable, CaseIterable, Codable, Equatable {
         case .reaction: return 7
         case .genericRepost: return 16
         case .report: return 1984
+        case .muteList: return 10000
         case .longformContent: return 30023
         case .dateBasedCalendarEvent: return 31922
         case .timeBasedCalendarEvent: return 31923

--- a/Sources/NostrSDK/Events/Calendars/DateBasedCalendarEvent.swift
+++ b/Sources/NostrSDK/Events/Calendars/DateBasedCalendarEvent.swift
@@ -28,7 +28,7 @@ public final class DateBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// Start date is represented by ``TimeOmittedDate``.
     /// `nil` is returned if the backing `start` tag is malformed.
     public var startDate: TimeOmittedDate? {
-        guard let startString = valueForRawTagName("start") else {
+        guard let startString = firstValueForRawTagName("start") else {
             return nil
         }
 
@@ -39,7 +39,7 @@ public final class DateBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// End date represented by ``TimeOmittedDate``.
     /// `nil` is returned if the backing `end` tag is malformed or if the calendar event ends on the same date as start.
     public var endDate: TimeOmittedDate? {
-        guard let endString = valueForRawTagName("end") else {
+        guard let endString = firstValueForRawTagName("end") else {
             return nil
         }
 

--- a/Sources/NostrSDK/Events/Calendars/TimeBasedCalendarEvent.swift
+++ b/Sources/NostrSDK/Events/Calendars/TimeBasedCalendarEvent.swift
@@ -26,7 +26,7 @@ public final class TimeBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// The start timestamp is represented by ``Date``.
     /// `nil` is returned if the backing `start` tag is malformed.
     public var startTimestamp: Date? {
-        guard let startString = valueForRawTagName("start"), let startSeconds = Int(startString) else {
+        guard let startString = firstValueForRawTagName("start"), let startSeconds = Int(startString) else {
             return nil
         }
 
@@ -37,7 +37,7 @@ public final class TimeBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// End timestamp represented by ``Date``.
     /// `nil` is returned if the backing `end` tag is malformed or if the calendar event ends instanteously.
     public var endTimestamp: Date? {
-        guard let endString = valueForRawTagName("end"), let endSeconds = Int(endString) else {
+        guard let endString = firstValueForRawTagName("end"), let endSeconds = Int(endString) else {
             return nil
         }
 
@@ -46,7 +46,7 @@ public final class TimeBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
 
     /// The time zone of the start timestamp.
     public var startTimeZone: TimeZone? {
-        guard let timeZoneIdentifier = valueForRawTagName("start_tzid") else {
+        guard let timeZoneIdentifier = firstValueForRawTagName("start_tzid") else {
             return nil
         }
 
@@ -56,7 +56,7 @@ public final class TimeBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     /// The time zone of the end timestamp.
     /// `nil` can be returned if the time zone identifier is malformed or if the time zone of the end timestamp is the same as the start timestamp.
     public var endTimeZone: TimeZone? {
-        guard let timeZoneIdentifier = valueForRawTagName("end_tzid") else {
+        guard let timeZoneIdentifier = firstValueForRawTagName("end_tzid") else {
             return nil
         }
 

--- a/Sources/NostrSDK/Events/GenericRepostEvent.swift
+++ b/Sources/NostrSDK/Events/GenericRepostEvent.swift
@@ -31,7 +31,7 @@ public class GenericRepostEvent: NostrEvent {
     
     /// The pubkey of the reposted event.
     var repostedEventPubkey: String? {
-        valueForTagName(.pubkey)
+        firstValueForTagName(.pubkey)
     }
     
     /// The note that is being reposted.
@@ -45,7 +45,7 @@ public class GenericRepostEvent: NostrEvent {
     
     /// The id of the event that is being reposted.
     var repostedEventId: String? {
-        valueForTagName(.event)
+        firstValueForTagName(.event)
     }
     
     /// The relay URL at which to fetch the reposted event.

--- a/Sources/NostrSDK/Events/LongformContentEvent.swift
+++ b/Sources/NostrSDK/Events/LongformContentEvent.swift
@@ -30,7 +30,7 @@ public final class LongformContentEvent: NostrEvent, HashtagInterpreting {
     
     /// The date of the first time the article was published.
     var publishedAt: Date? {
-        guard let unixTimeString = valueForTagName(.publishedAt),
+        guard let unixTimeString = firstValueForTagName(.publishedAt),
               let unixSeconds = TimeInterval(unixTimeString) else {
             return nil
         }
@@ -39,22 +39,22 @@ public final class LongformContentEvent: NostrEvent, HashtagInterpreting {
     
     /// A unique identifier for the content. Can be reused in the future for replacing the event.
     var identifier: String? {
-        valueForTagName(.identifier)
+        firstValueForTagName(.identifier)
     }
     
     /// The article title.
     var title: String? {
-        valueForTagName(.title)
+        firstValueForTagName(.title)
     }
     
     /// A summary of the content.
     var summary: String? {
-        valueForTagName(.summary)
+        firstValueForTagName(.summary)
     }
     
     /// A URL pointing to an image to be shown along with the title.
     var imageURL: URL? {
-        guard let imageURLString = valueForTagName(.image) else {
+        guard let imageURLString = firstValueForTagName(.image) else {
             return nil
         }
         return URL(string: imageURLString)

--- a/Sources/NostrSDK/Events/MuteListEvent.swift
+++ b/Sources/NostrSDK/Events/MuteListEvent.swift
@@ -1,0 +1,83 @@
+//
+//  MuteListEvent.swift
+//
+//
+//  Created by Bryan Montz on 12/15/23.
+//
+
+import Foundation
+
+/// An event that contains various things the user doesn't want to see in their feeds.
+///
+/// See [NIP-51](https://github.com/nostr-protocol/nips/blob/master/51.md#standard-lists).
+public final class MuteListEvent: NostrEvent, HashtagInterpreting, DirectMessageEncrypting {
+    public required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+    }
+    
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
+    init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+        try super.init(kind: .muteList, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+    
+    /// The publicly muted public keys (authors).
+    public var pubkeys: [String] {
+        allValues(forTagName: .pubkey) ?? []
+    }
+    
+    /// The publicly muted event ids (threads).
+    public var eventIds: [String] {
+        allValues(forTagName: .event) ?? []
+    }
+    
+    /// The publicly muted hashtags.
+    public var hashtags: [String] {
+        allValues(forTagName: .hashtag) ?? []
+    }
+    
+    /// The publicly muted keywords.
+    public var keywords: [String] {
+        allValues(forTagName: .word) ?? []
+    }
+    
+    /// The secretly muted public keys (authors).
+    public func secretPubkeys(using keypair: Keypair) -> [String] {
+        secretTags(withName: .pubkey, using: keypair)
+    }
+    
+    /// The secretly muted event ids (threads).
+    public func secretEventIds(using keypair: Keypair) -> [String] {
+        secretTags(withName: .event, using: keypair)
+    }
+    
+    /// The secretly muted hashtags.
+    public func secretHashtags(using keypair: Keypair) -> [String] {
+        secretTags(withName: .hashtag, using: keypair)
+    }
+    
+    /// The secretly muted keywords.
+    public func secretKeywords(using keypair: Keypair) -> [String] {
+        secretTags(withName: .word, using: keypair)
+    }
+    
+    private func secretTags(withName tagName: TagName, using keypair: Keypair) -> [String] {
+        secretTags(using: keypair).filter { $0.name == tagName.rawValue }.map { $0.value }
+    }
+    
+    /// The secret tags encrypted in the content of the event.
+    /// - Parameter keypair: The keypair to use to decrypt the content.
+    /// - Returns: The secret tags.
+    func secretTags(using keypair: Keypair) -> [Tag] {
+        guard let decryptedContent = try? decrypt(encryptedContent: content, privateKey: keypair.privateKey, publicKey: keypair.publicKey),
+              let jsonData = decryptedContent.data(using: .utf8) else {
+            return []
+        }
+        
+        let tags = try? JSONDecoder().decode([Tag].self, from: jsonData)
+        return tags ?? []
+    }
+}

--- a/Sources/NostrSDK/Events/MuteListEvent.swift
+++ b/Sources/NostrSDK/Events/MuteListEvent.swift
@@ -34,44 +34,39 @@ public final class MuteListEvent: NostrEvent, HashtagInterpreting, DirectMessage
         allValues(forTagName: .event) ?? []
     }
     
-    /// The publicly muted hashtags.
-    public var hashtags: [String] {
-        allValues(forTagName: .hashtag) ?? []
-    }
-    
     /// The publicly muted keywords.
     public var keywords: [String] {
         allValues(forTagName: .word) ?? []
     }
     
-    /// The secretly muted public keys (authors).
-    public func secretPubkeys(using keypair: Keypair) -> [String] {
-        secretTags(withName: .pubkey, using: keypair)
+    /// The privately muted public keys (authors).
+    public func privatePubkeys(using keypair: Keypair) -> [String] {
+        privateTags(withName: .pubkey, using: keypair)
     }
     
-    /// The secretly muted event ids (threads).
-    public func secretEventIds(using keypair: Keypair) -> [String] {
-        secretTags(withName: .event, using: keypair)
+    /// The privately muted event ids (threads).
+    public func privateEventIds(using keypair: Keypair) -> [String] {
+        privateTags(withName: .event, using: keypair)
     }
     
-    /// The secretly muted hashtags.
-    public func secretHashtags(using keypair: Keypair) -> [String] {
-        secretTags(withName: .hashtag, using: keypair)
+    /// The privately muted hashtags.
+    public func privateHashtags(using keypair: Keypair) -> [String] {
+        privateTags(withName: .hashtag, using: keypair)
     }
     
-    /// The secretly muted keywords.
-    public func secretKeywords(using keypair: Keypair) -> [String] {
-        secretTags(withName: .word, using: keypair)
+    /// The privately muted keywords.
+    public func privateKeywords(using keypair: Keypair) -> [String] {
+        privateTags(withName: .word, using: keypair)
     }
     
-    private func secretTags(withName tagName: TagName, using keypair: Keypair) -> [String] {
-        secretTags(using: keypair).filter { $0.name == tagName.rawValue }.map { $0.value }
+    private func privateTags(withName tagName: TagName, using keypair: Keypair) -> [String] {
+        privateTags(using: keypair).filter { $0.name == tagName.rawValue }.map { $0.value }
     }
     
-    /// The secret tags encrypted in the content of the event.
+    /// The private tags encrypted in the content of the event.
     /// - Parameter keypair: The keypair to use to decrypt the content.
-    /// - Returns: The secret tags.
-    func secretTags(using keypair: Keypair) -> [Tag] {
+    /// - Returns: The private tags.
+    func privateTags(using keypair: Keypair) -> [Tag] {
         guard let decryptedContent = try? decrypt(encryptedContent: content, privateKey: keypair.privateKey, publicKey: keypair.publicKey),
               let jsonData = decryptedContent.data(using: .utf8) else {
             return []

--- a/Sources/NostrSDK/Events/NostrEvent.swift
+++ b/Sources/NostrSDK/Events/NostrEvent.swift
@@ -90,13 +90,13 @@ public class NostrEvent: Codable {
                                            content: content)
     }
     
-    /// the String value for the provided ``TagName``, if it exists
-    public func valueForTagName(_ tag: TagName) -> String? {
-        valueForRawTagName(tag.rawValue)
+    /// the first String value for the provided ``TagName``, if it exists
+    public func firstValueForTagName(_ tag: TagName) -> String? {
+        firstValueForRawTagName(tag.rawValue)
     }
     
-    /// the String value for the provided raw tag name, if it exists
-    public func valueForRawTagName(_ tagName: String) -> String? {
+    /// the first String value for the provided raw tag name, if it exists
+    public func firstValueForRawTagName(_ tagName: String) -> String? {
         tags.first(where: { $0.name == tagName })?.value
     }
     

--- a/Sources/NostrSDK/Events/NostrEvent.swift
+++ b/Sources/NostrSDK/Events/NostrEvent.swift
@@ -99,4 +99,11 @@ public class NostrEvent: Codable {
     public func valueForRawTagName(_ tagName: String) -> String? {
         tags.first(where: { $0.name == tagName })?.value
     }
+    
+    /// All tags with the provided name.
+    /// - Parameter tag: The tag name to filter.
+    /// - Returns: The values associated with the tags of the provided name.
+    public func allValues(forTagName tag: TagName) -> [String]? {
+        tags.filter { $0.name == tag.rawValue }.map { $0.value }
+    }
 }

--- a/Sources/NostrSDK/Tag.swift
+++ b/Sources/NostrSDK/Tag.swift
@@ -41,6 +41,9 @@ public enum TagName: String {
     
     /// a web URL the event is referring to in some way. See [NIP-24 - Extra metadata fields and tags](https://github.com/nostr-protocol/nips/blob/master/24.md#tags).
     case webURL = "r"
+    
+    /// a keyword to mute
+    case word
 }
 
 /// A constant that describes a type of reference to an event.
@@ -163,5 +166,11 @@ public class Tag: Codable, Equatable {
         name == tag.name &&
         value == tag.value &&
         otherParameters == tag.otherParameters
+    }
+}
+
+extension Tag: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        "Tag(name: \"\(name)\", value: \"\(value)\")"
     }
 }

--- a/Tests/NostrSDKTests/EventCreatingTests.swift
+++ b/Tests/NostrSDKTests/EventCreatingTests.swift
@@ -286,6 +286,95 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
         XCTAssertThrowsError(try reportNote(noteToReport, reportType: .impersonation, additionalInformation: "mean words", signedBy: Keypair.test))
     }
     
+    func testMuteListEvent() throws {
+        let mutedPubkeys = [
+            "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2",
+            "72341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"
+        ]
+        
+        let secretlyMutedPubkeys = [
+            "52341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2",
+            "42341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"
+        ]
+        
+        let mutedEventIds = [
+            "964880cab60cab8e510b21714f93b45a288261c49b9a5413f18f69105824410a",
+            "05759f0b085181cce6f9784125ca46b71cebbfb6963f029c45e679c9eff6e46f"
+        ]
+        
+        let secretlyMutedEventIds = [
+            "761563ea69f4f07539d06a9f78c31c910e82044db8707dab5b8c7ab3b2d00153",
+            "7c77d79c2780a074aa26891faf44d9bc1d61fb75813bb2ee9b71d787f34d6a1a"
+        ]
+        
+        let mutedHashtags = [
+            "politics",
+            "religion"
+        ]
+        
+        let secretlyMutedHashtags = [
+            "left",
+            "right"
+        ]
+        
+        let mutedKeywords = [
+            "sportsball",
+            "pokemon"
+        ]
+        
+        let secretlyMutedKeywords = [
+            "up",
+            "down"
+        ]
+        
+        let event = try muteList(withPubliclyMutedPubkeys: mutedPubkeys,
+                                 secretlyMutedPubkeys: secretlyMutedPubkeys,
+                                 publiclyMutedEventIds: mutedEventIds,
+                                 secretlyMutedEventIds: secretlyMutedEventIds,
+                                 publiclyMutedHashtags: mutedHashtags,
+                                 secretlyMutedHashtags: secretlyMutedHashtags,
+                                 publiclyMutedKeywords: mutedKeywords,
+                                 secretlyMutedKeywords: secretlyMutedKeywords,
+                                 signedBy: Keypair.test)
+        
+        // check public tags
+        let expectedTags = [
+            Tag(name: .pubkey, value: "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
+            Tag(name: .pubkey, value: "72341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
+            Tag(name: .event, value: "964880cab60cab8e510b21714f93b45a288261c49b9a5413f18f69105824410a"),
+            Tag(name: .event, value: "05759f0b085181cce6f9784125ca46b71cebbfb6963f029c45e679c9eff6e46f"),
+            Tag(name: .hashtag, value: "politics"),
+            Tag(name: .hashtag, value: "religion"),
+            Tag(name: .word, value: "sportsball"),
+            Tag(name: .word, value: "pokemon")
+        ]
+        
+        XCTAssertEqual(event.tags, expectedTags)
+        
+        XCTAssertEqual(event.pubkeys, mutedPubkeys)
+        XCTAssertEqual(event.eventIds, mutedEventIds)
+        XCTAssertEqual(event.hashtags, mutedHashtags)
+        XCTAssertEqual(event.keywords, mutedKeywords)
+        
+        // check secret tags
+        let expectedSecretTags = [
+            Tag(name: .pubkey, value: "52341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
+            Tag(name: .pubkey, value: "42341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
+            Tag(name: .event, value: "761563ea69f4f07539d06a9f78c31c910e82044db8707dab5b8c7ab3b2d00153"),
+            Tag(name: .event, value: "7c77d79c2780a074aa26891faf44d9bc1d61fb75813bb2ee9b71d787f34d6a1a"),
+            Tag(name: .hashtag, value: "left"),
+            Tag(name: .hashtag, value: "right"),
+            Tag(name: .word, value: "up"),
+            Tag(name: .word, value: "down")
+        ]
+        
+        let secretTags = event.secretTags(using: Keypair.test)
+        
+        XCTAssertEqual(secretTags, expectedSecretTags)
+        
+        try verifyEvent(event)
+    }
+    
     func testLongformContentEvent() throws {
         let identifier = "my-blog-post"
         let title = "My Blog Post"

--- a/Tests/NostrSDKTests/EventCreatingTests.swift
+++ b/Tests/NostrSDKTests/EventCreatingTests.swift
@@ -292,7 +292,7 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
             "72341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"
         ]
         
-        let secretlyMutedPubkeys = [
+        let privatelyMutedPubkeys = [
             "52341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2",
             "42341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"
         ]
@@ -302,7 +302,7 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
             "05759f0b085181cce6f9784125ca46b71cebbfb6963f029c45e679c9eff6e46f"
         ]
         
-        let secretlyMutedEventIds = [
+        let privatelyMutedEventIds = [
             "761563ea69f4f07539d06a9f78c31c910e82044db8707dab5b8c7ab3b2d00153",
             "7c77d79c2780a074aa26891faf44d9bc1d61fb75813bb2ee9b71d787f34d6a1a"
         ]
@@ -312,7 +312,7 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
             "religion"
         ]
         
-        let secretlyMutedHashtags = [
+        let privatelyMutedHashtags = [
             "left",
             "right"
         ]
@@ -322,19 +322,19 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
             "pokemon"
         ]
         
-        let secretlyMutedKeywords = [
+        let privatelyMutedKeywords = [
             "up",
             "down"
         ]
         
         let event = try muteList(withPubliclyMutedPubkeys: mutedPubkeys,
-                                 secretlyMutedPubkeys: secretlyMutedPubkeys,
+                                 privatelyMutedPubkeys: privatelyMutedPubkeys,
                                  publiclyMutedEventIds: mutedEventIds,
-                                 secretlyMutedEventIds: secretlyMutedEventIds,
+                                 privatelyMutedEventIds: privatelyMutedEventIds,
                                  publiclyMutedHashtags: mutedHashtags,
-                                 secretlyMutedHashtags: secretlyMutedHashtags,
+                                 privatelyMutedHashtags: privatelyMutedHashtags,
                                  publiclyMutedKeywords: mutedKeywords,
-                                 secretlyMutedKeywords: secretlyMutedKeywords,
+                                 privatelyMutedKeywords: privatelyMutedKeywords,
                                  signedBy: Keypair.test)
         
         // check public tags
@@ -356,8 +356,8 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
         XCTAssertEqual(event.hashtags, mutedHashtags)
         XCTAssertEqual(event.keywords, mutedKeywords)
         
-        // check secret tags
-        let expectedSecretTags = [
+        // check private tags
+        let expectedPrivateTags = [
             Tag(name: .pubkey, value: "52341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
             Tag(name: .pubkey, value: "42341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
             Tag(name: .event, value: "761563ea69f4f07539d06a9f78c31c910e82044db8707dab5b8c7ab3b2d00153"),
@@ -368,9 +368,9 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
             Tag(name: .word, value: "down")
         ]
         
-        let secretTags = event.secretTags(using: Keypair.test)
+        let privateTags = event.privateTags(using: Keypair.test)
         
-        XCTAssertEqual(secretTags, expectedSecretTags)
+        XCTAssertEqual(privateTags, expectedPrivateTags)
         
         try verifyEvent(event)
     }

--- a/Tests/NostrSDKTests/EventDecodingTests.swift
+++ b/Tests/NostrSDKTests/EventDecodingTests.swift
@@ -397,4 +397,23 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(event.content, "Flight to Nostrica")
         XCTAssertEqual(event.signature, "57cdb0735645a7ff7112c2d863c425a75e82b540412117609c1c32bee833622a82acacd836b2790f0f08082e2700cdf1ac363c2aae1db87e613824fea2907845")
     }
+    
+    func testDecodeMuteListEvent() throws {
+        let event: MuteListEvent = try decodeFixture(filename: "mute_list")
+        
+        XCTAssertEqual(event.id, "acfc1402d926b88a26dffc94162e399f2b35d7c7503a1fde2f2cc6d11d33ad88")
+        XCTAssertEqual(event.pubkey, "9947f9659dd80c3682402b612f5447e28249997fb3709500c32a585eb0977340")
+        XCTAssertEqual(event.kind, .muteList)
+        
+        XCTAssertTrue(event.tags.contains(Tag(name: .pubkey, value: "07ecf9838136fe430fac43fa0860dbc62a0aac0729c5a33df1192ce75e330c9f")))
+        XCTAssertTrue(event.tags.contains(Tag(name: .hashtag, value: "testing")))
+        XCTAssertTrue(event.tags.contains(Tag(name: .hashtag, value: "test2")))
+        
+        let secretTags = event.secretTags(using: .test)
+        XCTAssertTrue(secretTags.contains(Tag(name: .pubkey, value: "6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93")))
+        XCTAssertTrue(secretTags.contains(Tag(name: .hashtag, value: "sportsball")))
+        XCTAssertTrue(secretTags.contains(Tag(name: .hashtag, value: "footstr")))
+        
+        XCTAssertEqual(event.secretHashtags(using: .test), ["sportsball", "footstr"])
+    }
 }

--- a/Tests/NostrSDKTests/EventDecodingTests.swift
+++ b/Tests/NostrSDKTests/EventDecodingTests.swift
@@ -409,11 +409,11 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertTrue(event.tags.contains(Tag(name: .hashtag, value: "testing")))
         XCTAssertTrue(event.tags.contains(Tag(name: .hashtag, value: "test2")))
         
-        let secretTags = event.secretTags(using: .test)
+        let secretTags = event.privateTags(using: .test)
         XCTAssertTrue(secretTags.contains(Tag(name: .pubkey, value: "6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93")))
         XCTAssertTrue(secretTags.contains(Tag(name: .hashtag, value: "sportsball")))
         XCTAssertTrue(secretTags.contains(Tag(name: .hashtag, value: "footstr")))
         
-        XCTAssertEqual(event.secretHashtags(using: .test), ["sportsball", "footstr"])
+        XCTAssertEqual(event.privateHashtags(using: .test), ["sportsball", "footstr"])
     }
 }

--- a/Tests/NostrSDKTests/Fixtures/mute_list.json
+++ b/Tests/NostrSDKTests/Fixtures/mute_list.json
@@ -1,0 +1,26 @@
+{
+  "created_at": 1702745356,
+  "content": "wKJz27MlbU3E/T0rVWac+yUn2kiUOyppR3cK+JGTAPyG2+LoheLrtHgspl4oDFqKLs7cIg0fdX/RP06At2Ms7PpEABFZu0G/RupuJSghPel380978OJCd0lX5+8U8SX8T4JdLjZJ3OeRGpjilDafmg==?iv=5t0jLTyHSTmXITrTRB0qNA==",
+  "tags": [
+    [
+      "t",
+      "testing"
+    ],
+    [
+      "t",
+      "test2"
+    ],
+    [
+      "p",
+      "07ecf9838136fe430fac43fa0860dbc62a0aac0729c5a33df1192ce75e330c9f"
+    ],
+    [
+      "title",
+      "Mute"
+    ]
+  ],
+  "kind": 10000,
+  "pubkey": "9947f9659dd80c3682402b612f5447e28249997fb3709500c32a585eb0977340",
+  "id": "acfc1402d926b88a26dffc94162e399f2b35d7c7503a1fde2f2cc6d11d33ad88",
+  "sig": "test"
+}


### PR DESCRIPTION
Implements the first NIP-51 list event: a kind 10000 MuteListEvent.
https://github.com/nostr-protocol/nips/blob/master/51.md#standard-lists

Other list types will follow in a subsequent PR.