### PR TITLE
Tags: add shorthand functions for easier usage and readability

### DIFF
--- a/Sources/NostrSDK/EventCreating.swift
+++ b/Sources/NostrSDK/EventCreating.swift
@@ -75,7 +75,7 @@ public extension EventCreating {
     ///
     /// > Note: [NIP-02 Specification](https://github.com/nostr-protocol/nips/blob/master/02.md#contact-list-and-petnames)
     func contactList(withPubkeys pubkeys: [String], signedBy keypair: Keypair) throws -> ContactListEvent {
-        try contactList(withPubkeyTags: pubkeys.map { Tag(name: .pubkey, value: $0) },
+        try contactList(withPubkeyTags: pubkeys.map { .pubkey($0) },
                         signedBy: keypair)
     }
     
@@ -109,7 +109,7 @@ public extension EventCreating {
             throw EventCreatingError.invalidInput
         }
 
-        let recipientTag = Tag(name: .pubkey, value: pubkey.hex)
+        let recipientTag = Tag.pubkey(pubkey.hex)
         return try DirectMessageEvent(content: encryptedMessage, tags: [recipientTag], signedBy: keypair)
     }
     
@@ -129,7 +129,7 @@ public extension EventCreating {
             throw EventCreatingError.invalidInput
         }
         
-        let tags = creatorValidatedEvents.map { Tag(name: .event, value: $0.id) }
+        let tags: [Tag] = creatorValidatedEvents.map { .event($0.id) }
         return try DeletionEvent(content: reason ?? "", tags: tags, signedBy: keypair)
     }
     
@@ -145,14 +145,14 @@ public extension EventCreating {
         guard let stringifiedJSON = String(data: jsonData, encoding: .utf8) else {
             throw EventCreatingError.invalidInput
         }
-        var tags = [
-            Tag(name: .event, value: event.id),
-            Tag(name: .pubkey, value: event.pubkey)
+        var tags: [Tag] = [
+            .event(event.id),
+            .pubkey(event.pubkey)
         ]
         if event.kind == .textNote {
             return try TextNoteRepostEvent(content: stringifiedJSON, tags: tags, signedBy: keypair)
         } else {
-            tags.append(Tag(name: .kind, value: String(event.kind.rawValue)))
+            tags.append(.kind(event.kind))
             
             return try GenericRepostEvent(content: stringifiedJSON, tags: tags, signedBy: keypair)
         }
@@ -167,8 +167,8 @@ public extension EventCreating {
     ///
     /// See [NIP-25 - Reactions](https://github.com/nostr-protocol/nips/blob/master/25.md)
     func reaction(withContent content: String, reactedEvent: NostrEvent, signedBy keypair: Keypair) throws -> ReactionEvent {
-        let eventTag = Tag(name: .event, value: reactedEvent.id)
-        let pubkeyTag = Tag(name: .pubkey, value: reactedEvent.pubkey)
+        let eventTag = Tag.event(reactedEvent.id)
+        let pubkeyTag = Tag.pubkey(reactedEvent.pubkey)
 
         var tags = reactedEvent.tags.filter { $0.name == TagName.event.rawValue || $0.name == TagName.pubkey.rawValue }
         tags.append(eventTag)
@@ -186,8 +186,8 @@ public extension EventCreating {
     ///
     /// See [NIP-25 - Reactions](https://github.com/nostr-protocol/nips/blob/master/25.md)
     func reaction(withCustomEmoji customEmoji: CustomEmoji, reactedEvent: NostrEvent, signedBy keypair: Keypair) throws -> ReactionEvent {
-        let eventTag = Tag(name: .event, value: reactedEvent.id)
-        let pubkeyTag = Tag(name: .pubkey, value: reactedEvent.pubkey)
+        let eventTag = Tag.event(reactedEvent.id)
+        let pubkeyTag = Tag.pubkey(reactedEvent.pubkey)
 
         var tags = reactedEvent.tags.filter { $0.name == TagName.event.rawValue || $0.name == TagName.pubkey.rawValue }
         tags.append(eventTag)
@@ -206,7 +206,7 @@ public extension EventCreating {
     /// - Returns: The signed ``ReportEvent``.
     func reportUser(withPublicKey pubkey: PublicKey, reportType: ReportType, additionalInformation: String = "", signedBy keypair: Keypair) throws -> ReportEvent {
         try ReportEvent(content: additionalInformation,
-                        tags: [Tag(name: .pubkey, value: pubkey.hex, otherParameters: [reportType.rawValue])],
+                        tags: [.pubkey(pubkey.hex, otherParameters: [reportType.rawValue])],
                         signedBy: keypair)
     }
     
@@ -221,9 +221,9 @@ public extension EventCreating {
         guard reportType != .impersonation else {
             throw EventCreatingError.invalidInput
         }
-        let tags = [
-            Tag(name: .event, value: note.id, otherParameters: [reportType.rawValue]),
-            Tag(name: .pubkey, value: note.pubkey)
+        let tags: [Tag] = [
+            .event(note.id, otherParameters: [reportType.rawValue]),
+            .pubkey(note.pubkey)
         ]
         return try ReportEvent(content: additionalInformation, tags: tags, signedBy: keypair)
     }
@@ -252,13 +252,13 @@ public extension EventCreating {
         var publicTags = [Tag]()
         
         for pubkey in publiclyMutedPubkeys {
-            publicTags.append(Tag(name: .pubkey, value: pubkey))
+            publicTags.append(.pubkey(pubkey))
         }
         for eventId in publiclyMutedEventIds {
-            publicTags.append(Tag(name: .event, value: eventId))
+            publicTags.append(.event(eventId))
         }
         for hashtag in publiclyMutedHashtags {
-            publicTags.append(Tag(name: .hashtag, value: hashtag))
+            publicTags.append(.hashtag(hashtag))
         }
         for keyword in publiclyMutedKeywords {
             publicTags.append(Tag(name: .word, value: keyword))
@@ -328,7 +328,7 @@ public extension EventCreating {
         
         if let hashtags {
             for hashtag in hashtags {
-                tags.append(Tag(name: .hashtag, value: hashtag))
+                tags.append(.hashtag(hashtag))
             }
         }
         
@@ -388,7 +388,7 @@ public extension EventCreating {
         }
 
         if let hashtags, !hashtags.isEmpty {
-            tags += hashtags.map { Tag(name: .hashtag, value: $0) }
+            tags += hashtags.map { .hashtag($0) }
         }
 
         if let references, !references.isEmpty {
@@ -457,7 +457,7 @@ public extension EventCreating {
         }
 
         if let hashtags {
-            tags += hashtags.map { Tag(name: .hashtag, value: $0) }
+            tags += hashtags.map { .hashtag($0) }
         }
 
         if let references {

--- a/Sources/NostrSDK/Events/Calendars/CalendarEventParticipant.swift
+++ b/Sources/NostrSDK/Events/Calendars/CalendarEventParticipant.swift
@@ -59,8 +59,8 @@ public struct CalendarEventParticipant: PubkeyProviding, RelayProviding, RelayUR
         if let role, !role.isEmpty {
             otherParameters.append(role)
         }
-
-        tag = Tag(name: .pubkey, value: pubkey.hex, otherParameters: otherParameters)
+        
+        tag = Tag.pubkey(pubkey.hex, otherParameters: otherParameters)
     }
 }
 

--- a/Sources/NostrSDK/Events/ContactListEvent.swift
+++ b/Sources/NostrSDK/Events/ContactListEvent.swift
@@ -47,7 +47,7 @@ public final class ContactListEvent: NostrEvent {
     
     /// Pubkeys for followed/known profiles.
     public var contactPubkeys: [String] {
-        tags.filter({ $0.name == TagName.pubkey.rawValue }).map { $0.value }
+        allValues(forTagName: .pubkey) ?? []
     }
     
     /// Pubkey tags for followed/known profiles.

--- a/Sources/NostrSDK/Events/DeletionEvent.swift
+++ b/Sources/NostrSDK/Events/DeletionEvent.swift
@@ -33,6 +33,6 @@ public final class DeletionEvent: NostrEvent {
     
     /// The event ids that the creator requests deletion for.
     public var deletedEventIds: [String] {
-        tags.filter { $0.name == TagName.event.rawValue }.map { $0.value }
+        allValues(forTagName: .event) ?? []
     }
 }

--- a/Sources/NostrSDK/Events/Tags/HashtagInterpreting.swift
+++ b/Sources/NostrSDK/Events/Tags/HashtagInterpreting.swift
@@ -12,7 +12,6 @@ public protocol HashtagInterpreting: NostrEvent {}
 public extension HashtagInterpreting {
     /// The hashtags of the event.
     var hashtags: [String] {
-        tags.filter { $0.name == TagName.hashtag.rawValue }
-            .map { $0.value }
+        allValues(forTagName: .hashtag) ?? []
     }
 }

--- a/Sources/NostrSDK/Events/Tags/ReferenceTagInterpreting.swift
+++ b/Sources/NostrSDK/Events/Tags/ReferenceTagInterpreting.swift
@@ -12,7 +12,6 @@ public protocol ReferenceTagInterpreting: NostrEvent {}
 public extension ReferenceTagInterpreting {
     /// The reference URLs of the event.
     var references: [URL] {
-        tags.filter { $0.name == TagName.webURL.rawValue }
-            .compactMap { URL(string: $0.value) }
+        allValues(forTagName: .webURL)?.compactMap { URL(string: $0) } ?? []
     }
 }

--- a/Sources/NostrSDK/Events/TextNoteEvent.swift
+++ b/Sources/NostrSDK/Events/TextNoteEvent.swift
@@ -27,20 +27,18 @@ public final class TextNoteEvent: NostrEvent, CustomEmojiInterpreting {
     
     /// Pubkeys mentioned in the note content.
     public var mentionedPubkeys: [String] {
-        let pubkeyTags = tags.filter { $0.name == TagName.pubkey.rawValue }
-        return pubkeyTags.map { $0.value }
+        allValues(forTagName: .pubkey) ?? []
     }
     
     /// Events mentioned in the note content.
     public var mentionedEventIds: [String] {
-        let eventTags = tags.filter { $0.name == TagName.event.rawValue }
-        return eventTags.map { $0.value }
+        allValues(forTagName: .event) ?? []
     }
     
     /// a short subject for a text note, similar to subjects in emails.
     ///
     /// See [NIP-14 - Subject tag in Text events](https://github.com/nostr-protocol/nips/blob/master/14.md).
     public var subject: String? {
-        tags.first(where: { $0.name == TagName.subject.rawValue })?.value
+        firstValueForTagName(.subject)
     }
 }

--- a/Sources/NostrSDK/Tag.swift
+++ b/Sources/NostrSDK/Tag.swift
@@ -172,6 +172,42 @@ public class Tag: Codable, Equatable {
     }
 }
 
+/// Shortcuts for creating common tags
+extension Tag {
+    
+    /// An event ``Tag`` with the provided id and other parameters.
+    /// - Parameters:
+    ///   - eventId: The event id.
+    ///   - otherParameters: The other parameters.
+    /// - Returns: The event ``Tag``.
+    static func event(_ eventId: String, otherParameters: [String] = []) -> Tag {
+        Tag(name: .event, value: eventId, otherParameters: otherParameters)
+    }
+    
+    /// A hashtag ``Tag`` with the provided value.
+    /// - Parameter hashtag: The hashtag.
+    /// - Returns: The hashtag ``Tag``.
+    static func hashtag(_ hashtag: String) -> Tag {
+        Tag(name: .hashtag, value: hashtag)
+    }
+    
+    /// A kind ``Tag`` with the provided value.
+    /// - Parameter kind: The kind (``EventKind``).
+    /// - Returns: The kind ``Tag``.
+    static func kind(_ kind: EventKind) -> Tag {
+        Tag(name: .kind, value: String(kind.rawValue))
+    }
+    
+    /// A pubkey ``Tag`` with the provided pubkey.
+    /// - Parameters:
+    ///   - pubkey: The pubkey.
+    ///   - otherParameters: The other parameters.
+    /// - Returns: The pubkey ``Tag``.
+    static func pubkey(_ pubkey: String, otherParameters: [String] = []) -> Tag {
+        Tag(name: .pubkey, value: pubkey, otherParameters: otherParameters)
+    }
+}
+
 extension Tag: CustomDebugStringConvertible {
     public var debugDescription: String {
         "Tag(name: \"\(name)\", value: \"\(value)\")"

--- a/Tests/NostrSDKTests/Calendars/CalendarEventParticipantTests.swift
+++ b/Tests/NostrSDKTests/Calendars/CalendarEventParticipantTests.swift
@@ -14,7 +14,7 @@ final class CalendarEventParticipantTests: XCTestCase {
         let pubkey = Keypair.test.publicKey
         let relay = "wss://relay.nostrsdk.com"
         let role = "organizer"
-        let tag = Tag(name: .pubkey, value: pubkey.hex, otherParameters: [relay, role])
+        let tag = Tag.pubkey(pubkey.hex, otherParameters: [relay, role])
         let calendarEventParticipant = try XCTUnwrap(CalendarEventParticipant(pubkeyTag: tag))
 
         XCTAssertEqual(calendarEventParticipant.pubkey, pubkey)

--- a/Tests/NostrSDKTests/EventCreatingTests.swift
+++ b/Tests/NostrSDKTests/EventCreatingTests.swift
@@ -97,9 +97,9 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
                                     signedBy: Keypair.test)
         
         let expectedTags: [Tag] = [
-            Tag(name: .pubkey, value: "83y9iuhw9u0t8thw8w80u"),
-            Tag(name: .pubkey, value: "19048ut34h23y89jio3r8"),
-            Tag(name: .pubkey, value: "5r623gyewfbh8uuiq83rd")
+            .pubkey("83y9iuhw9u0t8thw8w80u"),
+            .pubkey("19048ut34h23y89jio3r8"),
+            .pubkey("5r623gyewfbh8uuiq83rd")
         ]
         
         XCTAssertEqual(event.tags, expectedTags)
@@ -109,9 +109,9 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
     
     func testCreateContactListEventWithPetnames() throws {
         let tags: [Tag] = [
-            Tag(name: .pubkey, value: "83y9iuhw9u0t8thw8w80u", otherParameters: ["bob"]),
-            Tag(name: .pubkey, value: "19048ut34h23y89jio3r8", otherParameters: ["alice"]),
-            Tag(name: .pubkey, value: "5r623gyewfbh8uuiq83rd", otherParameters: ["steve"])
+            .pubkey("83y9iuhw9u0t8thw8w80u", otherParameters: ["bob"]),
+            .pubkey("19048ut34h23y89jio3r8", otherParameters: ["alice"]),
+            .pubkey("5r623gyewfbh8uuiq83rd", otherParameters: ["steve"])
         ]
         
         let event = try contactList(withPubkeyTags: tags,
@@ -125,7 +125,7 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
     func testDirectMessageEvent() throws {
         let content = "Secret message."
         let recipientPubKey = Keypair.test.publicKey
-        let recipientTag = Tag(name: .pubkey, value: recipientPubKey.hex)
+        let recipientTag = Tag.pubkey(recipientPubKey.hex)
 
         let event = try directMessage(withContent: content, toRecipient: recipientPubKey, signedBy: Keypair.test)
 
@@ -171,8 +171,8 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
         
         XCTAssertEqual(repostEvent.kind, .repost)
         
-        XCTAssertTrue(repostEvent.tags.contains(Tag(name: .pubkey, value: "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2")))
-        XCTAssertTrue(repostEvent.tags.contains(Tag(name: .event, value: "fa5ed84fc8eeb959fd39ad8e48388cfc33075991ef8e50064cfcecfd918bb91b")))
+        XCTAssertTrue(repostEvent.tags.contains(.pubkey("82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2")))
+        XCTAssertTrue(repostEvent.tags.contains(.event("fa5ed84fc8eeb959fd39ad8e48388cfc33075991ef8e50064cfcecfd918bb91b")))
         
         let repostedNote = try XCTUnwrap(repostEvent.repostedNote)
         XCTAssertEqual(repostedNote.id, "fa5ed84fc8eeb959fd39ad8e48388cfc33075991ef8e50064cfcecfd918bb91b")
@@ -195,9 +195,9 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
         XCTAssertEqual(event.reactedEventPubkey, reactedEvent.pubkey)
         XCTAssertEqual(event.content, "🤙")
 
-        let expectedTags = [
-            Tag(name: .event, value: reactedEvent.id),
-            Tag(name: .pubkey, value: reactedEvent.pubkey)
+        let expectedTags: [Tag] = [
+            .event(reactedEvent.id),
+            .pubkey(reactedEvent.pubkey)
         ]
         XCTAssertEqual(event.tags, expectedTags)
 
@@ -222,9 +222,9 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
         XCTAssertEqual(event.content, ":ostrich:")
         XCTAssertEqual(event.customEmojis, [customEmoji])
 
-        let expectedTags = [
-            Tag(name: .event, value: reactedEvent.id),
-            Tag(name: .pubkey, value: reactedEvent.pubkey),
+        let expectedTags: [Tag] = [
+            .event(reactedEvent.id),
+            .pubkey(reactedEvent.pubkey),
             Tag(name: .emoji, value: "ostrich", otherParameters: [imageURLString])
         ]
         XCTAssertEqual(event.tags, expectedTags)
@@ -239,9 +239,9 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
         XCTAssertFalse(repostEvent is TextNoteRepostEvent)
         XCTAssertEqual(repostEvent.kind, .genericRepost)
         
-        XCTAssertTrue(repostEvent.tags.contains(Tag(name: .pubkey, value: "test-pubkey")))
-        XCTAssertTrue(repostEvent.tags.contains(Tag(name: .event, value: "test-id")))
-        XCTAssertTrue(repostEvent.tags.contains(Tag(name: .kind, value: "2")))
+        XCTAssertTrue(repostEvent.tags.contains(.pubkey("test-pubkey")))
+        XCTAssertTrue(repostEvent.tags.contains(.event("test-id")))
+        XCTAssertTrue(repostEvent.tags.contains(.kind(.recommendServer)))
         
         let repostedEvent = try XCTUnwrap(repostEvent.repostedEvent)
         XCTAssertEqual(repostedEvent.id, "test-id")
@@ -257,7 +257,7 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
         XCTAssertEqual(report.kind, .report)
         XCTAssertEqual(report.content, "he's lying!")
         
-        let expectedTag = Tag(name: .pubkey, value: Keypair.test.publicKey.hex, otherParameters: ["impersonation"])
+        let expectedTag = Tag.pubkey(Keypair.test.publicKey.hex, otherParameters: ["impersonation"])
         XCTAssertTrue(report.tags.contains(expectedTag))
         
         try verifyEvent(report)
@@ -271,10 +271,10 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
         XCTAssertEqual(report.kind, .report)
         XCTAssertEqual(report.content, "mean words")
         
-        let expectedPubkeyTag = Tag(name: .pubkey, value: "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2")
+        let expectedPubkeyTag = Tag.pubkey("82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2")
         XCTAssertTrue(report.tags.contains(expectedPubkeyTag))
         
-        let expectedEventTag = Tag(name: .event, value: noteToReport.id, otherParameters: ["profanity"])
+        let expectedEventTag = Tag.event(noteToReport.id, otherParameters: ["profanity"])
         XCTAssertTrue(report.tags.contains(expectedEventTag))
         
         try verifyEvent(report)
@@ -338,13 +338,13 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
                                  signedBy: Keypair.test)
         
         // check public tags
-        let expectedTags = [
-            Tag(name: .pubkey, value: "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
-            Tag(name: .pubkey, value: "72341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
-            Tag(name: .event, value: "964880cab60cab8e510b21714f93b45a288261c49b9a5413f18f69105824410a"),
-            Tag(name: .event, value: "05759f0b085181cce6f9784125ca46b71cebbfb6963f029c45e679c9eff6e46f"),
-            Tag(name: .hashtag, value: "politics"),
-            Tag(name: .hashtag, value: "religion"),
+        let expectedTags: [Tag] = [
+            .pubkey("82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
+            .pubkey("72341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
+            .event("964880cab60cab8e510b21714f93b45a288261c49b9a5413f18f69105824410a"),
+            .event("05759f0b085181cce6f9784125ca46b71cebbfb6963f029c45e679c9eff6e46f"),
+            .hashtag("politics"),
+            .hashtag("religion"),
             Tag(name: .word, value: "sportsball"),
             Tag(name: .word, value: "pokemon")
         ]
@@ -357,13 +357,13 @@ final class EventCreatingTests: XCTestCase, EventCreating, EventVerifying, Fixtu
         XCTAssertEqual(event.keywords, mutedKeywords)
         
         // check private tags
-        let expectedPrivateTags = [
-            Tag(name: .pubkey, value: "52341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
-            Tag(name: .pubkey, value: "42341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
-            Tag(name: .event, value: "761563ea69f4f07539d06a9f78c31c910e82044db8707dab5b8c7ab3b2d00153"),
-            Tag(name: .event, value: "7c77d79c2780a074aa26891faf44d9bc1d61fb75813bb2ee9b71d787f34d6a1a"),
-            Tag(name: .hashtag, value: "left"),
-            Tag(name: .hashtag, value: "right"),
+        let expectedPrivateTags: [Tag] = [
+            .pubkey("52341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
+            .pubkey("42341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2"),
+            .event("761563ea69f4f07539d06a9f78c31c910e82044db8707dab5b8c7ab3b2d00153"),
+            .event("7c77d79c2780a074aa26891faf44d9bc1d61fb75813bb2ee9b71d787f34d6a1a"),
+            .hashtag("left"),
+            .hashtag("right"),
             Tag(name: .word, value: "up"),
             Tag(name: .word, value: "down")
         ]

--- a/Tests/NostrSDKTests/EventDecodingTests.swift
+++ b/Tests/NostrSDKTests/EventDecodingTests.swift
@@ -106,9 +106,9 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(event.createdAt, 1682080184)
         XCTAssertEqual(event.kind, .textNote)
 
-        let expectedTags = [
-            Tag(name: .event, value: "93930d65435d49db723499335473920795e7f13c45600dcfad922135cf44bd63"),
-            Tag(name: .pubkey, value: "f8e6c64342f1e052480630e27e1016dce35fc3a614e60434fef4aa2503328ca9")
+        let expectedTags: [Tag] = [
+            .event("93930d65435d49db723499335473920795e7f13c45600dcfad922135cf44bd63"),
+            .pubkey("f8e6c64342f1e052480630e27e1016dce35fc3a614e60434fef4aa2503328ca9")
         ]
         XCTAssertEqual(event.tags, expectedTags)
         XCTAssertEqual(event.content, "I think it stays persistent on your profile, but interface setting doesn’t persist. Bug.  ")
@@ -126,9 +126,9 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(event.createdAt, 1682080184)
         XCTAssertEqual(event.kind, .textNote)
 
-        let expectedTags = [
-            Tag(name: .event, value: "93930d65435d49db723499335473920795e7f13c45600dcfad922135cf44bd63"),
-            Tag(name: .pubkey, value: "f8e6c64342f1e052480630e27e1016dce35fc3a614e60434fef4aa2503328ca9"),
+        let expectedTags: [Tag] = [
+            .event("93930d65435d49db723499335473920795e7f13c45600dcfad922135cf44bd63"),
+            .pubkey("f8e6c64342f1e052480630e27e1016dce35fc3a614e60434fef4aa2503328ca9"),
             Tag(name: .subject, value: "test-subject")
         ]
         XCTAssertEqual(event.tags, expectedTags)
@@ -172,8 +172,8 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(event.createdAt, 1691768179)
         XCTAssertEqual(event.kind, .directMessage)
 
-        let expectedTags = [
-            Tag(name: .pubkey, value: "9947f9659dd80c3682402b612f5447e28249997fb3709500c32a585eb0977340")
+        let expectedTags: [Tag] = [
+            .pubkey("9947f9659dd80c3682402b612f5447e28249997fb3709500c32a585eb0977340")
         ]
         XCTAssertEqual(expectedTags, event.tags)
 
@@ -205,8 +205,8 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(event.kind, .contactList)
         
         let expectedTags: [Tag] = [
-            Tag(name: .pubkey, value: "pubkey1", otherParameters: ["wss://relay1.com", "alice"]),
-            Tag(name: .pubkey, value: "pubkey2", otherParameters: ["wss://relay2.com", "bob"])
+            .pubkey("pubkey1", otherParameters: ["wss://relay1.com", "alice"]),
+            .pubkey("pubkey2", otherParameters: ["wss://relay2.com", "bob"])
         ]
         XCTAssertEqual(event.tags, expectedTags)
         XCTAssertEqual(event.signature, "hex-signature")
@@ -225,7 +225,7 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
 
         XCTAssertEqual(event.contactPubkeys, expectedPubkeys)
 
-        let firstTag = Tag(name: .pubkey, value: "3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681")
+        let firstTag = Tag.pubkey("3efdaebb1d8923ebd99c9e7ace3b4194ab45512e2be79c1b7d68d9243e0d2681")
         XCTAssertEqual(event.contactPubkeyTags.first, firstTag)
 
         let expectedRelays = [
@@ -248,9 +248,9 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(event.createdAt, 1684817569)
         XCTAssertEqual(event.kind, .repost)
 
-        let expectedTags = [
-            Tag(name: .event, value: "6663efd8ffb35325af90a84cb223dc388e9d355abf7319fe5c4c5ca7f37e9a34"),
-            Tag(name: .pubkey, value: "33eecd2e2fae31f36c0bdb843d43611426ee5c023889f0401c1b8f5008e59689")
+        let expectedTags: [Tag] = [
+            .event("6663efd8ffb35325af90a84cb223dc388e9d355abf7319fe5c4c5ca7f37e9a34"),
+            .pubkey("33eecd2e2fae31f36c0bdb843d43611426ee5c023889f0401c1b8f5008e59689")
         ]
         XCTAssertEqual(event.tags, expectedTags)
         XCTAssertTrue(event.content.hasPrefix("{\"pubkey\":\"33eecd2e2fae31f36c0bdb843d43611426ee5c023889f0401c1b8f5008e59689\""))
@@ -286,9 +286,9 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(event.createdAt, 1689029084)
         XCTAssertEqual(event.kind, .reaction)
 
-        let expectedTags = [
-            Tag(name: .event, value: "62dcc905c282dd712bbe6b47d2e40feb333f8a0c39899617f4ca37337199ede0"),
-            Tag(name: .pubkey, value: "e1ff3bfdd4e40315959b08b4fcc8245eaa514637e1d4ec2ae166b743341be1af")
+        let expectedTags: [Tag] = [
+            .event("62dcc905c282dd712bbe6b47d2e40feb333f8a0c39899617f4ca37337199ede0"),
+            .pubkey("e1ff3bfdd4e40315959b08b4fcc8245eaa514637e1d4ec2ae166b743341be1af")
         ]
         XCTAssertEqual(event.tags, expectedTags)
         XCTAssertEqual(event.reactedEventId, "62dcc905c282dd712bbe6b47d2e40feb333f8a0c39899617f4ca37337199ede0")
@@ -305,9 +305,9 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(event.createdAt, 1699768152)
         XCTAssertEqual(event.kind, .reaction)
 
-        let expectedTags = [
-            Tag(name: .event, value: "dc0e8b27b37ec7854ec0d5b24c39901a8cf933be3b420ca3cee6242279f54a48"),
-            Tag(name: .pubkey, value: "9947f9659dd80c3682402b612f5447e28249997fb3709500c32a585eb0977340"),
+        let expectedTags: [Tag] = [
+            .event("dc0e8b27b37ec7854ec0d5b24c39901a8cf933be3b420ca3cee6242279f54a48"),
+            .pubkey("9947f9659dd80c3682402b612f5447e28249997fb3709500c32a585eb0977340"),
             Tag(name: .emoji, value: "ostrich", otherParameters: ["https://nostrsdk.com/ostrich.png"])
         ]
         let imageURL = try XCTUnwrap(URL(string: "https://nostrsdk.com/ostrich.png"))
@@ -405,14 +405,14 @@ final class EventDecodingTests: XCTestCase, FixtureLoading {
         XCTAssertEqual(event.pubkey, "9947f9659dd80c3682402b612f5447e28249997fb3709500c32a585eb0977340")
         XCTAssertEqual(event.kind, .muteList)
         
-        XCTAssertTrue(event.tags.contains(Tag(name: .pubkey, value: "07ecf9838136fe430fac43fa0860dbc62a0aac0729c5a33df1192ce75e330c9f")))
-        XCTAssertTrue(event.tags.contains(Tag(name: .hashtag, value: "testing")))
-        XCTAssertTrue(event.tags.contains(Tag(name: .hashtag, value: "test2")))
+        XCTAssertTrue(event.tags.contains(.pubkey("07ecf9838136fe430fac43fa0860dbc62a0aac0729c5a33df1192ce75e330c9f")))
+        XCTAssertTrue(event.tags.contains(.hashtag("testing")))
+        XCTAssertTrue(event.tags.contains(.hashtag("test2")))
         
         let secretTags = event.privateTags(using: .test)
-        XCTAssertTrue(secretTags.contains(Tag(name: .pubkey, value: "6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93")))
-        XCTAssertTrue(secretTags.contains(Tag(name: .hashtag, value: "sportsball")))
-        XCTAssertTrue(secretTags.contains(Tag(name: .hashtag, value: "footstr")))
+        XCTAssertTrue(secretTags.contains(.pubkey("6e468422dfb74a5738702a8823b9b28168abab8655faacb6853cd0ee15deee93")))
+        XCTAssertTrue(secretTags.contains(.hashtag("sportsball")))
+        XCTAssertTrue(secretTags.contains(.hashtag("footstr")))
         
         XCTAssertEqual(event.privateHashtags(using: .test), ["sportsball", "footstr"])
     }

--- a/Tests/NostrSDKTests/RelayRequestEncodingTests.swift
+++ b/Tests/NostrSDKTests/RelayRequestEncodingTests.swift
@@ -18,8 +18,8 @@ final class RelayRequestEncodingTests: XCTestCase, FixtureLoading, JSONTesting {
     }
 
     func testEncodeEvent() throws {
-        let eventTag = Tag(name: .event, value: "93930d65435d49db723499335473920795e7f13c45600dcfad922135cf44bd63")
-        let pubkeyTag = Tag(name: .pubkey, value: "f8e6c64342f1e052480630e27e1016dce35fc3a614e60434fef4aa2503328ca9")
+        let eventTag = Tag.event("93930d65435d49db723499335473920795e7f13c45600dcfad922135cf44bd63")
+        let pubkeyTag = Tag.pubkey("f8e6c64342f1e052480630e27e1016dce35fc3a614e60434fef4aa2503328ca9")
         let event = NostrEvent(id: "fa5ed84fc8eeb959fd39ad8e48388cfc33075991ef8e50064cfcecfd918bb91b",
                                pubkey: "82341f882b6eabcd2ba7f1ef90aad961cf074af15b9ef44a09f9d2a8fbfbe6a2",
                                createdAt: 1682080184,


### PR DESCRIPTION
We can now optionally use shorthand functions for creating tags.

```swift
let tag = Tag.pubkey(<pubkey hex>)

let tags: [Tag] = [.pubkey(<pubkey hex>)]
```

I created these functions for tags that are used frequently, but more could be added. The regular initializer is unchanged and can still be used when desired.