### PR TITLE
Replace Sodium with CryptoSwift

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "7892a123f7e8d0fe62f9f03728b17bbd4f94df5c",
+        "version" : "1.8.1"
+      }
+    },
+    {
       "identity" : "secp256k1.swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GigaBitcoin/secp256k1.swift",
@@ -25,14 +34,6 @@
       "state" : {
         "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
         "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "swift-sodium",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/jedisct1/swift-sodium.git",
-      "state" : {
-        "revision" : "63240810df971557fe9badc557257bdfbfeb90a3"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
         .package(url: "https://github.com/GigaBitcoin/secp256k1.swift", from: "0.12.2"),
-        .package(url: "https://github.com/jedisct1/swift-sodium.git", revision: "63240810df971557fe9badc557257bdfbfeb90a3")
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMajor(from: "1.8.1"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -26,7 +26,7 @@ let package = Package(
             name: "NostrSDK",
             dependencies: [
                 .product(name: "secp256k1", package: "secp256k1.swift"),
-                .product(name: "Clibsodium", package: "swift-sodium")
+                "CryptoSwift"
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Using `Sodium`, which is backed by a C library, broke documentation generation for some reason. We were using it for the `ChaCha20` cipher for NIP-44 encryption, introduced in this commit: https://github.com/nostr-sdk/nostr-sdk-ios/commit/f1384b7a447a3d16cf97a93141d8a2001e884c74

This PR replaces `Sodium` with `CryptoSwift`, a pure Swift library, which implements the ChaCha20 cipher and seems to fix documentation generation. I tried it both locally and on the `main` remote branch on my fork.

The fact that `NIP44v2EncryptingTests` passes gives me confidence that the `CryptoSwift` usage is functionally equivalent to what we were doing with `Sodium`.