### PR TITLE
Make NostrEvent conform to the Hashable protocol and change its Equatable implementation to compare against all its properties

### DIFF
--- a/Sources/NostrSDK/CustomEmoji.swift
+++ b/Sources/NostrSDK/CustomEmoji.swift
@@ -10,7 +10,8 @@ import Foundation
 /// [NIP-30 Custom Emoji](https://github.com/nostr-protocol/nips/blob/master/30.md)
 public class CustomEmoji: CustomEmojiValidating, Equatable {
     public static func == (lhs: CustomEmoji, rhs: CustomEmoji) -> Bool {
-        lhs.isEqual(to: rhs)
+        lhs.shortcode == rhs.shortcode &&
+        lhs.imageURL == rhs.imageURL
     }
 
     /// A name given for the emoji, which MUST be comprised of only alphanumeric characters and underscores.
@@ -35,11 +36,6 @@ public class CustomEmoji: CustomEmojiValidating, Equatable {
         guard isValidShortcode(shortcode) else {
             return nil
         }
-    }
-
-    func isEqual(to customEmoji: CustomEmoji) -> Bool {
-        shortcode == customEmoji.shortcode &&
-        imageURL == customEmoji.imageURL
     }
 }
 

--- a/Sources/NostrSDK/EventKind.swift
+++ b/Sources/NostrSDK/EventKind.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A constant defining the kind of an event.
-public enum EventKind: RawRepresentable, CaseIterable, Codable, Equatable {
+public enum EventKind: RawRepresentable, CaseIterable, Codable, Equatable, Hashable {
 
     public typealias RawValue = Int
 
@@ -122,6 +122,10 @@ public enum EventKind: RawRepresentable, CaseIterable, Codable, Equatable {
     public init(rawValue: Int) {
         self = Self.allCases.first { $0.rawValue == rawValue }
                ?? .unknown(rawValue)
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
     }
 
     public var rawValue: RawValue {

--- a/Sources/NostrSDK/Events/Calendars/CalendarEventParticipant.swift
+++ b/Sources/NostrSDK/Events/Calendars/CalendarEventParticipant.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// A participant in a calendar event.
-public struct CalendarEventParticipant: PubkeyProviding, RelayProviding, RelayURLValidating, Equatable {
+public struct CalendarEventParticipant: PubkeyProviding, RelayProviding, RelayURLValidating, Equatable, Hashable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.tag == rhs.tag
     }
@@ -61,6 +61,10 @@ public struct CalendarEventParticipant: PubkeyProviding, RelayProviding, RelayUR
         }
         
         tag = Tag.pubkey(pubkey.hex, otherParameters: otherParameters)
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(tag)
     }
 }
 

--- a/Sources/NostrSDK/Events/NostrEvent.swift
+++ b/Sources/NostrSDK/Events/NostrEvent.swift
@@ -12,7 +12,13 @@ import Foundation
 /// > Note: [NIP-01 Specification](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures)
 public class NostrEvent: Codable, Equatable, Hashable {
     public static func == (lhs: NostrEvent, rhs: NostrEvent) -> Bool {
-        lhs.isEqual(to: rhs)
+        lhs.id == rhs.id &&
+        lhs.pubkey == rhs.pubkey &&
+        lhs.createdAt == rhs.createdAt &&
+        lhs.kind == rhs.kind &&
+        lhs.tags == rhs.tags &&
+        lhs.content == rhs.content &&
+        lhs.signature == rhs.signature
     }
     
     /// 32-byte, lowercase, hex-encoded sha256 of the serialized event data
@@ -123,15 +129,5 @@ public class NostrEvent: Codable, Equatable, Hashable {
     /// - Returns: The values associated with the tags of the provided name.
     public func allValues(forTagName tag: TagName) -> [String] {
         tags.filter { $0.name == tag.rawValue }.map { $0.value }
-    }
-
-    func isEqual(to nostrEvent: NostrEvent) -> Bool {
-        id == nostrEvent.id &&
-        pubkey == nostrEvent.pubkey &&
-        createdAt == nostrEvent.createdAt &&
-        kind == nostrEvent.kind &&
-        tags == nostrEvent.tags &&
-        content == nostrEvent.content &&
-        signature == nostrEvent.signature
     }
 }

--- a/Sources/NostrSDK/Events/NostrEvent.swift
+++ b/Sources/NostrSDK/Events/NostrEvent.swift
@@ -10,9 +10,9 @@ import Foundation
 /// A structure that describes a Nostr event.
 ///
 /// > Note: [NIP-01 Specification](https://github.com/nostr-protocol/nips/blob/master/01.md#events-and-signatures)
-public class NostrEvent: Codable, Equatable {
+public class NostrEvent: Codable, Equatable, Hashable {
     public static func == (lhs: NostrEvent, rhs: NostrEvent) -> Bool {
-        lhs.id == rhs.id
+        lhs.isEqual(to: rhs)
     }
     
     /// 32-byte, lowercase, hex-encoded sha256 of the serialized event data
@@ -69,7 +69,17 @@ public class NostrEvent: Codable, Equatable {
                                                 content: content)
         signature = try keypair.privateKey.signatureForContent(id)
     }
-    
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(pubkey)
+        hasher.combine(createdAt)
+        hasher.combine(kind)
+        hasher.combine(tags)
+        hasher.combine(content)
+        hasher.combine(signature)
+    }
+
     /// The date the event was created.
     public var createdDate: Date {
         Date(timeIntervalSince1970: TimeInterval(createdAt))
@@ -113,5 +123,15 @@ public class NostrEvent: Codable, Equatable {
     /// - Returns: The values associated with the tags of the provided name.
     public func allValues(forTagName tag: TagName) -> [String] {
         tags.filter { $0.name == tag.rawValue }.map { $0.value }
+    }
+
+    func isEqual(to nostrEvent: NostrEvent) -> Bool {
+        id == nostrEvent.id &&
+        pubkey == nostrEvent.pubkey &&
+        createdAt == nostrEvent.createdAt &&
+        kind == nostrEvent.kind &&
+        tags == nostrEvent.tags &&
+        content == nostrEvent.content &&
+        signature == nostrEvent.signature
     }
 }

--- a/Sources/NostrSDK/Events/Tags/EventCoordinates.swift
+++ b/Sources/NostrSDK/Events/Tags/EventCoordinates.swift
@@ -13,7 +13,7 @@ enum EventCoordinatesError: Error {
 
 /// Coordinates to a (maybe parameterized) replaceable event.
 /// See [NIP-01 Tags](https://github.com/nostr-protocol/nips/blob/master/01.md#tags).
-public struct EventCoordinates: PubkeyProviding, RelayProviding, RelayURLValidating, Equatable {
+public struct EventCoordinates: PubkeyProviding, RelayProviding, RelayURLValidating, Equatable, Hashable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.tag == rhs.tag
     }
@@ -116,6 +116,10 @@ public struct EventCoordinates: PubkeyProviding, RelayProviding, RelayURLValidat
                 otherParameters: otherParameters
             )
         )
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(tag)
     }
 }
 

--- a/Sources/NostrSDK/Tag.swift
+++ b/Sources/NostrSDK/Tag.swift
@@ -60,7 +60,7 @@ public enum TagName: String {
 /// See [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md) for an initial definition of tags.
 /// See [NIP-10](https://github.com/nostr-protocol/nips/blob/master/10.md) for further refinement and additions to tags.
 /// See https://github.com/nostr-protocol/nips/tree/b4cdc1a73d415c79c35655fa02f5e55cd1f2a60c#standardized-tags for a list of all standardized tags.
-public class Tag: Codable, Equatable {
+public class Tag: Codable, Equatable, Hashable {
     public static func == (lhs: Tag, rhs: Tag) -> Bool {
         lhs.isEqual(to: rhs)
     }
@@ -110,7 +110,13 @@ public class Tag: Codable, Equatable {
         }
         self.otherParameters = otherParameters
     }
-    
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(value)
+        hasher.combine(otherParameters)
+    }
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.unkeyedContainer()
         try container.encode(name)

--- a/Sources/NostrSDK/Tag.swift
+++ b/Sources/NostrSDK/Tag.swift
@@ -62,7 +62,9 @@ public enum TagName: String {
 /// See https://github.com/nostr-protocol/nips/tree/b4cdc1a73d415c79c35655fa02f5e55cd1f2a60c#standardized-tags for a list of all standardized tags.
 public class Tag: Codable, Equatable, Hashable {
     public static func == (lhs: Tag, rhs: Tag) -> Bool {
-        lhs.isEqual(to: rhs)
+        lhs.name == rhs.name &&
+        lhs.value == rhs.value &&
+        lhs.otherParameters == rhs.otherParameters
     }
     
     /// The name of the tag.
@@ -124,12 +126,6 @@ public class Tag: Codable, Equatable, Hashable {
         for value in otherParameters {
             try container.encode(value)
         }
-    }
-    
-    func isEqual(to tag: Tag) -> Bool {
-        name == tag.name &&
-        value == tag.value &&
-        otherParameters == tag.otherParameters
     }
     
     /// The raw format of a tag, which can be serialized and transmitted.

--- a/Tests/NostrSDKTests/Events/NostrEventTests.swift
+++ b/Tests/NostrSDKTests/Events/NostrEventTests.swift
@@ -1,0 +1,47 @@
+//
+//  NostrEventTests.swift
+//  
+//
+//  Created by Terry Yiu on 4/19/24.
+//
+
+@testable import NostrSDK
+import XCTest
+
+final class NostrEventTests: XCTestCase, FixtureLoading {
+
+    func testEquatable() throws {
+        let textNoteEvent: TextNoteEvent = try decodeFixture(filename: "text_note")
+        let nostrEvent: NostrEvent = try decodeFixture(filename: "text_note")
+        let differentEvent: NostrEvent = NostrEvent(
+            id: nostrEvent.id,
+            pubkey: nostrEvent.pubkey,
+            createdAt: nostrEvent.createdAt,
+            kind: nostrEvent.kind,
+            tags: nostrEvent.tags,
+            content: "This content was written by an impersonator.",
+            signature: nostrEvent.signature
+        )
+
+        XCTAssertEqual(textNoteEvent, nostrEvent)
+        XCTAssertNotEqual(nostrEvent, differentEvent)
+    }
+
+    func testHashable() throws {
+        let textNoteEvent: TextNoteEvent = try decodeFixture(filename: "text_note")
+        let nostrEvent: NostrEvent = try decodeFixture(filename: "text_note")
+        let differentEvent: NostrEvent = NostrEvent(
+            id: nostrEvent.id,
+            pubkey: nostrEvent.pubkey,
+            createdAt: nostrEvent.createdAt,
+            kind: nostrEvent.kind,
+            tags: nostrEvent.tags,
+            content: "This content was written by an impersonator.",
+            signature: nostrEvent.signature
+        )
+
+        XCTAssertEqual(textNoteEvent.hashValue, nostrEvent.hashValue)
+        XCTAssertNotEqual(nostrEvent.hashValue, differentEvent.hashValue)
+    }
+
+}


### PR DESCRIPTION
This change enables NostrEvent and its subclasses to be hashable, which is great for allowing indexing and deduplicating in Set and Dictionary data structures.

This change also prevents events with the same `id` from being erroneously equated the same as another event with the same `id` if any of its other properties are different. Note that this is a breaking change.