### PR TITLE
Fix build by increasing minimum Swift version to 5.8

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        swift: ['5.7.1', '5.8', '5.9']
+        swift: ['5.8', '5.9', '5.10']
 
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Nostr SDK for Apple Platforms is a native Swift library that enables developers 
 
 ## Minimum Requirements
 
-- Swift 5.7.1
+- Swift 5.8
 - iOS 15
 - macOS 12
 


### PR DESCRIPTION
I suspect there was a breaking change with GitHub's `macos` runner, which caused it to not recognize Swift 5.7. Let's just bump the minimum supported Swift version to 5.8. I also added 5.10 to the test matrix.