### PR TITLE
Upgrade GitHub Actions Checkout to V4 to fix Node.js deprecation warnings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Pages
       uses: actions/configure-pages@v3
     - name: Generate Docs

--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -9,7 +9,7 @@ jobs:
   SwiftLint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: GitHub Action for SwiftLint
       uses: norio-nomura/action-swiftlint@3.2.1
       with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Swift
       uses: SwiftyLab/setup-swift@latest

--- a/Sources/NostrSDK/Events/BookmarksListEvent.swift
+++ b/Sources/NostrSDK/Events/BookmarksListEvent.swift
@@ -139,8 +139,8 @@ public extension EventCreating {
         var encryptedContent: String?
         if !privateTags.isEmpty {
             let rawPrivateTags = privateTags.map { $0.raw }
-            if let unencryptedData = try? JSONSerialization.data(withJSONObject: rawPrivateTags),
-               let unencryptedContent = String(data: unencryptedData, encoding: .utf8) {
+            if let unencryptedData = try? JSONSerialization.data(withJSONObject: rawPrivateTags) {
+                let unencryptedContent = String(decoding: unencryptedData, as: UTF8.self)
                 encryptedContent = try legacyEncrypt(content: unencryptedContent,
                                                      privateKey: keypair.privateKey,
                                                      publicKey: keypair.publicKey)

--- a/Sources/NostrSDK/Events/GenericRepostEvent.swift
+++ b/Sources/NostrSDK/Events/GenericRepostEvent.swift
@@ -36,8 +36,8 @@ public class GenericRepostEvent: NostrEvent, RelayURLValidating {
     
     /// The note that is being reposted.
     var repostedEvent: NostrEvent? {
-        guard let jsonData = content.data(using: .utf8),
-              let note: NostrEvent = try? JSONDecoder().decode(NostrEvent.self, from: jsonData) else {
+        let jsonData = Data(content.utf8)
+        guard let note: NostrEvent = try? JSONDecoder().decode(NostrEvent.self, from: jsonData) else {
             return nil
         }
         return note
@@ -70,9 +70,7 @@ public extension EventCreating {
     /// See [NIP-18](https://github.com/nostr-protocol/nips/blob/master/18.md#reposts).
     func repost(event: NostrEvent, signedBy keypair: Keypair) throws -> GenericRepostEvent {
         let jsonData = try JSONEncoder().encode(event)
-        guard let stringifiedJSON = String(data: jsonData, encoding: .utf8) else {
-            throw EventCreatingError.invalidInput
-        }
+        let stringifiedJSON = String(decoding: jsonData, as: UTF8.self)
         var tags: [Tag] = [
             .event(event.id),
             .pubkey(event.pubkey)

--- a/Sources/NostrSDK/Events/GiftWrap/GiftWrapEvent.swift
+++ b/Sources/NostrSDK/Events/GiftWrap/GiftWrapEvent.swift
@@ -109,9 +109,7 @@ public extension EventCreating {
         signedBy keypair: Keypair
     ) throws -> GiftWrapEvent {
         let jsonData = try JSONEncoder().encode(seal)
-        guard let stringifiedJSON = String(data: jsonData, encoding: .utf8) else {
-            throw EventCreatingError.invalidInput
-        }
+        let stringifiedJSON = String(decoding: jsonData, as: UTF8.self)
 
         guard let randomKeypair = Keypair() else {
             throw GiftWrapError.keypairGenerationFailed

--- a/Sources/NostrSDK/Events/GiftWrap/SealEvent.swift
+++ b/Sources/NostrSDK/Events/GiftWrap/SealEvent.swift
@@ -86,10 +86,7 @@ public extension EventCreating {
         }
 
         let jsonData = try JSONEncoder().encode(rumor)
-        guard let stringifiedJSON = String(data: jsonData, encoding: .utf8) else {
-            throw EventCreatingError.invalidInput
-        }
-
+        let stringifiedJSON = String(decoding: jsonData, as: UTF8.self)
         let encryptedRumor = try encrypt(plaintext: stringifiedJSON, privateKeyA: keypair.privateKey, publicKeyB: recipient)
         return try SealEvent(content: encryptedRumor, createdAt: createdAt, signedBy: keypair)
     }

--- a/Sources/NostrSDK/Events/MetadataEvent.swift
+++ b/Sources/NostrSDK/Events/MetadataEvent.swift
@@ -112,9 +112,7 @@ public extension EventCreating {
     /// See [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md)
     func metadataEvent(withUserMetadata userMetadata: UserMetadata, customEmojis: [CustomEmoji] = [], signedBy keypair: Keypair) throws -> MetadataEvent {
         let metadataAsData = try JSONEncoder().encode(userMetadata)
-        guard let metadataAsString = String(data: metadataAsData, encoding: .utf8) else {
-            throw EventCreatingError.invalidInput
-        }
+        let metadataAsString = String(decoding: metadataAsData, as: UTF8.self)
         let customEmojiTags = customEmojis.map { $0.tag }
         return try MetadataEvent(content: metadataAsString, tags: customEmojiTags, signedBy: keypair)
     }

--- a/Sources/NostrSDK/Events/MuteListEvent.swift
+++ b/Sources/NostrSDK/Events/MuteListEvent.swift
@@ -98,8 +98,8 @@ public extension EventCreating {
         var encryptedContent: String?
         if !privateTags.isEmpty {
             let rawPrivateTags = privateTags.map { $0.raw }
-            if let unencryptedData = try? JSONSerialization.data(withJSONObject: rawPrivateTags),
-               let unencryptedContent = String(data: unencryptedData, encoding: .utf8) {
+            if let unencryptedData = try? JSONSerialization.data(withJSONObject: rawPrivateTags) {
+                let unencryptedContent = String(decoding: unencryptedData, as: UTF8.self)
                 encryptedContent = try legacyEncrypt(content: unencryptedContent,
                                                      privateKey: keypair.privateKey,
                                                      publicKey: keypair.publicKey)

--- a/Sources/NostrSDK/Events/TextNoteRepostEvent.swift
+++ b/Sources/NostrSDK/Events/TextNoteRepostEvent.swift
@@ -12,7 +12,7 @@ import Foundation
 /// See [NIP-18](https://github.com/nostr-protocol/nips/blob/master/18.md#reposts).
 public final class TextNoteRepostEvent: GenericRepostEvent {
     
-    override class var kind: EventKind {
+    override static var kind: EventKind {
         .repost
     }
     

--- a/Sources/NostrSDK/LegacyDirectMessageEncrypting.swift
+++ b/Sources/NostrSDK/LegacyDirectMessageEncrypting.swift
@@ -77,12 +77,11 @@ public extension LegacyDirectMessageEncrypting {
         let ivContentTrimmed = ivContent.dropFirst(3)
 
         guard let ivContentData = Data(base64Encoded: String(ivContentTrimmed)),
-              let decryptedContentData = AESDecrypt(data: encryptedContentData.bytes, iv: ivContentData.bytes, sharedSecret: sharedSecret),
-              let decryptedMessage = String(data: decryptedContentData, encoding: .utf8) else {
+              let decryptedContentData = AESDecrypt(data: encryptedContentData.bytes, iv: ivContentData.bytes, sharedSecret: sharedSecret) else {
             throw LegacyDirectMessageEncryptingError.decryptionError
         }
 
-        return decryptedMessage
+        return String(decoding: decryptedContentData, as: UTF8.self)
     }
 
     private func getSharedSecret(privateKey: PrivateKey, recipient pubkey: PublicKey) throws -> [UInt8] {

--- a/Sources/NostrSDK/NIP44v2Encrypting.swift
+++ b/Sources/NostrSDK/NIP44v2Encrypting.swift
@@ -149,12 +149,12 @@ extension NIP44v2Encrypting {
 
         guard unpaddedLength > 0,
               unpadded.count == unpaddedLength,
-              padded.count == 2 + paddedLength,
-              let result = String(data: Data(unpadded), encoding: .utf8) else {
+              padded.count == 2 + paddedLength
+              else {
             throw NIP44v2EncryptingError.paddingInvalid
         }
 
-        return result
+        return String(decoding: Data(unpadded), as: UTF8.self)
     }
 
     func decodePayload(_ payload: String) throws -> DecodedPayload {

--- a/Sources/NostrSDK/WebSocket.swift
+++ b/Sources/NostrSDK/WebSocket.swift
@@ -80,7 +80,7 @@ final class WebSocket: NSObject, URLSessionWebSocketDelegate {
 
         let reasonString: String?
         if let reason {
-            reasonString = String(data: reason, encoding: .utf8)
+            reasonString = String(decoding: reason, as: UTF8.self)
         } else {
             reasonString = nil
         }


### PR DESCRIPTION
Older versions of Checkout use deprecated Node.js versions.

We were getting these kinds of warnings in the build:

`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`

`The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/`

Upgrading to Checkout V4 fixes these warnings.

- [ ] Do not merge until https://github.com/nostr-sdk/nostr-sdk-ios/pull/162 gets merged
- [ ] Change this PR base branch to be `main` after the above PR is merged