### PR TITLE
Add NIP-19 bech32 identifier generation for note, nevent, and naddr prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following [NIPs](https://github.com/nostr-protocol/nips) are implemented:
 - [ ] [NIP-15: Nostr Marketplace (for resilient marketplaces)](https://github.com/nostr-protocol/nips/blob/master/15.md)
 - [ ] [NIP-17: Private Direct Messages](https://github.com/nostr-protocol/nips/blob/master/17.md)
 - [x] [NIP-18: Reposts](https://github.com/nostr-protocol/nips/blob/master/18.md)
-- [ ] [NIP-19: bech32-encoded entities](https://github.com/nostr-protocol/nips/blob/master/19.md)
+- [x] [NIP-19: bech32-encoded entities](https://github.com/nostr-protocol/nips/blob/master/19.md)
 - [ ] [NIP-21: `nostr:` URI scheme](https://github.com/nostr-protocol/nips/blob/master/21.md)
 - [x] [NIP-23: Long-form Content](https://github.com/nostr-protocol/nips/blob/master/23.md)
 - [x] [NIP-24: Extra metadata fields and tags](https://github.com/nostr-protocol/nips/blob/master/24.md)

--- a/Sources/NostrSDK/Bech32IdentifierType.swift
+++ b/Sources/NostrSDK/Bech32IdentifierType.swift
@@ -1,0 +1,19 @@
+//
+//  Bech32IdentifierType.swift
+//
+//
+//  Created by Terry Yiu on 6/30/24.
+//
+
+/// The type of Bech32-encoded identifier.
+/// These identifiers can be used to succinctly encapsulate metadata to aid in the discovery of events and users.
+/// See [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) for information about how these Bech32-encoded
+public enum Bech32IdentifierType: String {
+    case publicKey = "npub"
+    case privateKey = "nsec"
+    case note = "note"
+    case profile = "nprofile"
+    case event = "nevent"
+    case relay = "nrelay"
+    case address = "naddr"
+}

--- a/Sources/NostrSDK/Bech32IdentifierType.swift
+++ b/Sources/NostrSDK/Bech32IdentifierType.swift
@@ -7,7 +7,8 @@
 
 /// The type of Bech32-encoded identifier.
 /// These identifiers can be used to succinctly encapsulate metadata to aid in the discovery of events and users.
-/// See [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) for information about how these Bech32-encoded
+/// See [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md) for information about how these
+/// identifiers are encoded and used.
 public enum Bech32IdentifierType: String {
     case publicKey = "npub"
     case privateKey = "nsec"

--- a/Sources/NostrSDK/Events/AuthenticationEvent.swift
+++ b/Sources/NostrSDK/Events/AuthenticationEvent.swift
@@ -11,7 +11,7 @@ import Foundation
 /// This kind is not meant to be published or queried.
 ///
 /// See [NIP-42](https://github.com/nostr-protocol/nips/blob/master/42.md).
-public final class AuthenticationEvent: NostrEvent, RelayProviding, RelayURLValidating {
+public final class AuthenticationEvent: NostrEvent, RelayProviding {
     public required init(from decoder: Decoder) throws {
         try super.init(from: decoder)
     }

--- a/Sources/NostrSDK/Events/GenericRepostEvent.swift
+++ b/Sources/NostrSDK/Events/GenericRepostEvent.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A generic repost event (kind 16) can include any kind of event inside other than kind 1.
 /// > Note: Generic reposts SHOULD contain a `k` tag with the stringified kind number of the reposted event as its value.
 /// See [NIP-18](https://github.com/nostr-protocol/nips/blob/master/18.md#generic-reposts).
-public class GenericRepostEvent: NostrEvent, RelayURLValidating {
+public class GenericRepostEvent: NostrEvent {
     
     public required init(from decoder: Decoder) throws {
         try super.init(from: decoder)

--- a/Sources/NostrSDK/Events/NonParameterizedReplaceableEvent.swift
+++ b/Sources/NostrSDK/Events/NonParameterizedReplaceableEvent.swift
@@ -17,16 +17,16 @@ public extension NonParameterizedReplaceableEvent {
         return try? EventCoordinates(kind: kind, pubkey: publicKey, relayURL: relayURL)
     }
 
-    func shareableEventCoordinates(relayURLStrings: [String]? = nil, excludeAuthor: Bool = false, excludeKind: Bool = false) throws -> String {
+    func shareableEventCoordinates(relayURLStrings: [String]? = nil, includeAuthor: Bool = true, includeKind: Bool = true) throws -> String {
         let validatedRelayURLStrings = try relayURLStrings?.map {
             try validateRelayURLString($0)
         }.map { $0.absoluteString }
 
         var metadata = Metadata(relays: validatedRelayURLStrings, identifier: "")
-        if !excludeAuthor {
+        if includeAuthor {
             metadata.pubkey = pubkey
         }
-        if !excludeKind {
+        if includeKind {
             metadata.kind = UInt32(kind.rawValue)
         }
 

--- a/Sources/NostrSDK/Events/NonParameterizedReplaceableEvent.swift
+++ b/Sources/NostrSDK/Events/NonParameterizedReplaceableEvent.swift
@@ -18,18 +18,6 @@ public extension NonParameterizedReplaceableEvent {
     }
 
     func shareableEventCoordinates(relayURLStrings: [String]? = nil, includeAuthor: Bool = true, includeKind: Bool = true) throws -> String {
-        let validatedRelayURLStrings = try relayURLStrings?.map {
-            try validateRelayURLString($0)
-        }.map { $0.absoluteString }
-
-        var metadata = Metadata(relays: validatedRelayURLStrings, identifier: "")
-        if includeAuthor {
-            metadata.pubkey = pubkey
-        }
-        if includeKind {
-            metadata.kind = UInt32(kind.rawValue)
-        }
-
-        return try encodedIdentifier(with: metadata, identifierType: .address)
+        try shareableEventCoordinates(relayURLStrings: relayURLStrings, includeAuthor: includeAuthor, includeKind: includeKind, identifier: "")
     }
 }

--- a/Sources/NostrSDK/Events/NonParameterizedReplaceableEvent.swift
+++ b/Sources/NostrSDK/Events/NonParameterizedReplaceableEvent.swift
@@ -16,4 +16,20 @@ public extension NonParameterizedReplaceableEvent {
 
         return try? EventCoordinates(kind: kind, pubkey: publicKey, relayURL: relayURL)
     }
+
+    func shareableEventCoordinates(relayURLStrings: [String]? = nil, excludeAuthor: Bool = false, excludeKind: Bool = false) throws -> String {
+        let validatedRelayURLStrings = try relayURLStrings?.map {
+            try validateRelayURLString($0)
+        }.map { $0.absoluteString }
+
+        var metadata = Metadata(relays: validatedRelayURLStrings, identifier: "")
+        if !excludeAuthor {
+            metadata.pubkey = pubkey
+        }
+        if !excludeKind {
+            metadata.kind = UInt32(kind.rawValue)
+        }
+
+        return try encodedIdentifier(with: metadata, identifierType: .address)
+    }
 }

--- a/Sources/NostrSDK/Events/NostrEvent.swift
+++ b/Sources/NostrSDK/Events/NostrEvent.swift
@@ -155,12 +155,12 @@ extension NostrEvent: MetadataCoding, RelayURLValidating {
         guard let data = id.hexDecoded else {
             return nil
         }
-        return Bech32.encode(NostrEvent.bech32NoteIdPrefix, baseEightData: data)
+        return Bech32.encode(Bech32IdentifierType.note.rawValue, baseEightData: data)
     }
 
     /// Gets a shareable human-interactable event identifier for this event.
     /// The identifier is bech32-formatted with a prefix of `nevent` using a binary-encoded list of TLV (type-length-value).
-    /// The identifier have all the information needed for the event to be found, which includes the
+    /// The identifier has all the information needed for the event to be found, which includes the
     /// event id, optionally the relays, optionally the author's public key, and optionally the event kind number.
     /// - Parameters:
     ///   - relayURLs: The String representations of relay URLs in which the event is more likely to be found, encoded as ASCII.

--- a/Sources/NostrSDK/Events/NostrEvent.swift
+++ b/Sources/NostrSDK/Events/NostrEvent.swift
@@ -143,7 +143,6 @@ public class NostrEvent: Codable, Equatable, Hashable {
 }
 
 extension NostrEvent: MetadataCoding, RelayURLValidating {
-    private static let bech32NoteIdPrefix = "note"
 
     /// Gets a bare `note`-prefixed bech32-formatted human-friendly id of this event, or `nil` if it could not be generated.
     /// It is not meant to be used inside the standard NIP-01 event formats or inside the filters.

--- a/Sources/NostrSDK/Events/ParameterizedReplaceableEvent.swift
+++ b/Sources/NostrSDK/Events/ParameterizedReplaceableEvent.swift
@@ -24,18 +24,6 @@ public extension ParameterizedReplaceableEvent {
     }
 
     func shareableEventCoordinates(relayURLStrings: [String]? = nil, includeAuthor: Bool = true, includeKind: Bool = true) throws -> String {
-        let validatedRelayURLStrings = try relayURLStrings?.map {
-            try validateRelayURLString($0)
-        }.map { $0.absoluteString }
-
-        var metadata = Metadata(relays: validatedRelayURLStrings, identifier: identifier)
-        if includeAuthor {
-            metadata.pubkey = pubkey
-        }
-        if includeKind {
-            metadata.kind = UInt32(kind.rawValue)
-        }
-
-        return try encodedIdentifier(with: metadata, identifierType: .address)
+        try shareableEventCoordinates(relayURLStrings: relayURLStrings, includeAuthor: includeAuthor, includeKind: includeKind, identifier: identifier ?? "")
     }
 }

--- a/Sources/NostrSDK/Events/ParameterizedReplaceableEvent.swift
+++ b/Sources/NostrSDK/Events/ParameterizedReplaceableEvent.swift
@@ -23,16 +23,16 @@ public extension ParameterizedReplaceableEvent {
         return try? EventCoordinates(kind: kind, pubkey: publicKey, identifier: identifier, relayURL: relayURL)
     }
 
-    func shareableEventCoordinates(relayURLStrings: [String]? = nil, excludeAuthor: Bool = false, excludeKind: Bool = false) throws -> String {
+    func shareableEventCoordinates(relayURLStrings: [String]? = nil, includeAuthor: Bool = true, includeKind: Bool = true) throws -> String {
         let validatedRelayURLStrings = try relayURLStrings?.map {
             try validateRelayURLString($0)
         }.map { $0.absoluteString }
 
         var metadata = Metadata(relays: validatedRelayURLStrings, identifier: identifier)
-        if !excludeAuthor {
+        if includeAuthor {
             metadata.pubkey = pubkey
         }
-        if !excludeKind {
+        if includeKind {
             metadata.kind = UInt32(kind.rawValue)
         }
 

--- a/Sources/NostrSDK/Events/ReplaceableEvent.swift
+++ b/Sources/NostrSDK/Events/ReplaceableEvent.swift
@@ -15,4 +15,17 @@ public protocol ReplaceableEvent: NostrEvent {
     /// - Parameters:
     ///   - relayURL: A relay URL that this replaceable event could be found.
     func replaceableEventCoordinates(relayURL: URL?) -> EventCoordinates?
+
+    /// Gets a shareable human-interactable event coordinates for this replaceable event.
+    /// The coordinates are bech32-formatted with a prefix of `nevent` using a binary-encoded list of TLV (type-length-value).
+    /// The coordinates have all the information needed for this replaceable event to be found, which includes the
+    /// identifier (if it is parameterized), optionally the relays, optionally the author's public key, and optionally the event kind number.
+    /// - Parameters:
+    ///   - relayURLStrings: The String representations of relay URLs in which the event is more likely to be found, encoded as ASCII.
+    ///   - excludeAuthor: Whether the author public key should be excluded from the identifier.
+    ///   - excludeKind: Whether the event kind number should be excluded from the identifier.
+    /// - Throws: `URLError.Code.badURL`, `RelayURLError.invalidScheme`, `TLVCodingError.failedToEncode`
+    ///
+    /// > Note: [NIP-19 bech32-encoded entities](https://github.com/nostr-protocol/nips/blob/master/19.md)
+    func shareableEventCoordinates(relayURLStrings: [String]?, excludeAuthor: Bool, excludeKind: Bool) throws -> String
 }

--- a/Sources/NostrSDK/Events/ReplaceableEvent.swift
+++ b/Sources/NostrSDK/Events/ReplaceableEvent.swift
@@ -22,10 +22,10 @@ public protocol ReplaceableEvent: NostrEvent {
     /// identifier (if it is parameterized), optionally the relays, optionally the author's public key, and optionally the event kind number.
     /// - Parameters:
     ///   - relayURLStrings: The String representations of relay URLs in which the event is more likely to be found, encoded as ASCII.
-    ///   - excludeAuthor: Whether the author public key should be excluded from the identifier.
-    ///   - excludeKind: Whether the event kind number should be excluded from the identifier.
+    ///   - includeAuthor: Whether the author public key should be included in the identifier.
+    ///   - includeKind: Whether the event kind number should be included in the identifier.
     /// - Throws: `URLError.Code.badURL`, `RelayURLError.invalidScheme`, `TLVCodingError.failedToEncode`
     ///
     /// > Note: [NIP-19 bech32-encoded entities](https://github.com/nostr-protocol/nips/blob/master/19.md)
-    func shareableEventCoordinates(relayURLStrings: [String]?, excludeAuthor: Bool, excludeKind: Bool) throws -> String
+    func shareableEventCoordinates(relayURLStrings: [String]?, includeAuthor: Bool, includeKind: Bool) throws -> String
 }

--- a/Sources/NostrSDK/Events/ReplaceableEvent.swift
+++ b/Sources/NostrSDK/Events/ReplaceableEvent.swift
@@ -29,3 +29,21 @@ public protocol ReplaceableEvent: NostrEvent {
     /// > Note: [NIP-19 bech32-encoded entities](https://github.com/nostr-protocol/nips/blob/master/19.md)
     func shareableEventCoordinates(relayURLStrings: [String]?, includeAuthor: Bool, includeKind: Bool) throws -> String
 }
+
+extension ReplaceableEvent {
+    func shareableEventCoordinates(relayURLStrings: [String]?, includeAuthor: Bool, includeKind: Bool, identifier: String) throws -> String {
+        let validatedRelayURLStrings = try relayURLStrings?.map {
+            try validateRelayURLString($0)
+        }.map { $0.absoluteString }
+
+        var metadata = Metadata(relays: validatedRelayURLStrings, identifier: identifier)
+        if includeAuthor {
+            metadata.pubkey = pubkey
+        }
+        if includeKind {
+            metadata.kind = UInt32(kind.rawValue)
+        }
+
+        return try encodedIdentifier(with: metadata, identifierType: .address)
+    }
+}

--- a/Sources/NostrSDK/Keys.swift
+++ b/Sources/NostrSDK/Keys.swift
@@ -63,8 +63,6 @@ public struct Keypair {
 }
 
 public struct PublicKey: Equatable {
-    static let humanReadablePrefix = "npub"
-
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.hex == rhs.hex
     }
@@ -74,7 +72,7 @@ public struct PublicKey: Equatable {
     public let dataRepresentation: Data
 
     public init?(dataRepresentation: Data) {
-        self.init(npub: Bech32.encode(PublicKey.humanReadablePrefix, baseEightData: dataRepresentation))
+        self.init(npub: Bech32.encode(Bech32IdentifierType.publicKey.rawValue, baseEightData: dataRepresentation))
     }
 
     public init?(hex: String) {
@@ -97,7 +95,7 @@ public struct PublicKey: Equatable {
            return nil
         }
 
-        guard humanReadablePart == PublicKey.humanReadablePrefix else {
+        guard humanReadablePart == Bech32IdentifierType.publicKey.rawValue else {
             Loggers.keypairs.error("Could not create public key because the human readable part, \(humanReadablePart), is not equal to npub.")
             return nil
         }
@@ -114,14 +112,12 @@ public struct PublicKey: Equatable {
 }
 
 public struct PrivateKey {
-    static let humanReadablePrefix = "nsec"
-
     public let hex: String
     public let nsec: String
     public let dataRepresentation: Data
 
     public init?(dataRepresentation: Data) {
-        self.init(nsec: Bech32.encode(PrivateKey.humanReadablePrefix, baseEightData: dataRepresentation))
+        self.init(nsec: Bech32.encode(Bech32IdentifierType.privateKey.rawValue, baseEightData: dataRepresentation))
     }
 
     public init?(hex: String) {
@@ -144,7 +140,7 @@ public struct PrivateKey {
            return nil
         }
 
-        guard humanReadablePart == PrivateKey.humanReadablePrefix else {
+        guard humanReadablePart == Bech32IdentifierType.privateKey.rawValue else {
             Loggers.keypairs.error("Could not create private key because the human readable part, \(humanReadablePart), is not equal to nsec.")
             return nil
         }

--- a/Tests/NostrSDKTests/Events/NonParameterizedReplaceableEventTests.swift
+++ b/Tests/NostrSDKTests/Events/NonParameterizedReplaceableEventTests.swift
@@ -50,7 +50,7 @@ final class NonParameterizedReplaceableEventTests: XCTestCase, FixtureLoading, M
 
     func testShareableEventCoordinatesExcludeAuthor() throws {
         let event: MuteListEvent = try decodeFixture(filename: "mute_list")
-        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(excludeAuthor: true))
+        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(includeAuthor: false))
         XCTAssertEqual(shareableEventCoordinates, "naddr1qqqqxpqqqqn3qat5qqg")
 
         let metadata = try XCTUnwrap(decodedMetadata(from: shareableEventCoordinates))
@@ -63,7 +63,7 @@ final class NonParameterizedReplaceableEventTests: XCTestCase, FixtureLoading, M
 
     func testShareableEventCoordinatesExcludeKind() throws {
         let event: MuteListEvent = try decodeFixture(filename: "mute_list")
-        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(excludeKind: true))
+        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(includeKind: false))
         XCTAssertEqual(shareableEventCoordinates, "naddr1qqqqygyeglukt8wcpsmgysptvyh4g3lzsfyejlanwz2spse2tp0tp9mngq8y2x7g")
 
         let metadata = try XCTUnwrap(decodedMetadata(from: shareableEventCoordinates))

--- a/Tests/NostrSDKTests/Events/NonParameterizedReplaceableEventTests.swift
+++ b/Tests/NostrSDKTests/Events/NonParameterizedReplaceableEventTests.swift
@@ -1,0 +1,77 @@
+//
+//  NonParameterizedReplaceableEventTests.swift
+//
+//
+//  Created by Terry Yiu on 6/30/24.
+//
+
+@testable import NostrSDK
+import XCTest
+
+final class NonParameterizedReplaceableEventTests: XCTestCase, FixtureLoading, MetadataCoding {
+
+    func testReplaceableEventCoordinates() throws {
+        let event: MuteListEvent = try decodeFixture(filename: "mute_list")
+        let publicKey = try XCTUnwrap(PublicKey(hex: "9947f9659dd80c3682402b612f5447e28249997fb3709500c32a585eb0977340"))
+        let expectedReplaceableEventCoordinates = try XCTUnwrap(EventCoordinates(kind: .muteList, pubkey: publicKey))
+        XCTAssertEqual(event.replaceableEventCoordinates(relayURL: nil), expectedReplaceableEventCoordinates)
+    }
+
+    func testShareableEventCoordinates() throws {
+        let event: MuteListEvent = try decodeFixture(filename: "mute_list")
+        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates())
+        XCTAssertEqual(shareableEventCoordinates, "naddr1qqqqygyeglukt8wcpsmgysptvyh4g3lzsfyejlanwz2spse2tp0tp9mngqpsgqqqyugqp4hw4t")
+
+        let metadata = try XCTUnwrap(decodedMetadata(from: shareableEventCoordinates))
+        XCTAssertNil(metadata.eventId)
+        XCTAssertEqual(metadata.identifier, "")
+        XCTAssertEqual(metadata.pubkey, event.pubkey)
+        XCTAssertEqual(metadata.kind, UInt32(event.kind.rawValue))
+        XCTAssertEqual(metadata.relays, [])
+    }
+
+    func testShareableEventCoordinatesWithRelays() throws {
+        let relay1 = "wss://relay1.com"
+        let relay2 = "wss://relay2.com"
+
+        let event: MuteListEvent = try decodeFixture(filename: "mute_list")
+        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(relayURLStrings: [relay1, relay2]))
+        XCTAssertEqual(shareableEventCoordinates, "naddr1qqqqzyrhwden5te0wfjkcctexyhxxmmdqyg8wumn8ghj7un9d3shjv3wvdhk6q3qn9rljevamqxrdqjq9dsj74z8u2pynxtlkdcf2qxr9fv9avyhwdqqxpqqqqn3qtqh7yd")
+
+        let metadata = try XCTUnwrap(decodedMetadata(from: shareableEventCoordinates))
+        XCTAssertNil(metadata.eventId)
+        XCTAssertEqual(metadata.identifier, "")
+        XCTAssertEqual(metadata.pubkey, event.pubkey)
+        XCTAssertEqual(metadata.kind, UInt32(event.kind.rawValue))
+        XCTAssertEqual(metadata.relays?.count, 2)
+        XCTAssertEqual(metadata.relays?[0], relay1)
+        XCTAssertEqual(metadata.relays?[1], relay2)
+    }
+
+    func testShareableEventCoordinatesExcludeAuthor() throws {
+        let event: MuteListEvent = try decodeFixture(filename: "mute_list")
+        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(excludeAuthor: true))
+        XCTAssertEqual(shareableEventCoordinates, "naddr1qqqqxpqqqqn3qat5qqg")
+
+        let metadata = try XCTUnwrap(decodedMetadata(from: shareableEventCoordinates))
+        XCTAssertNil(metadata.eventId)
+        XCTAssertEqual(metadata.identifier, "")
+        XCTAssertNil(metadata.pubkey)
+        XCTAssertEqual(metadata.kind, UInt32(event.kind.rawValue))
+        XCTAssertEqual(metadata.relays, [])
+    }
+
+    func testShareableEventCoordinatesExcludeKind() throws {
+        let event: MuteListEvent = try decodeFixture(filename: "mute_list")
+        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(excludeKind: true))
+        XCTAssertEqual(shareableEventCoordinates, "naddr1qqqqygyeglukt8wcpsmgysptvyh4g3lzsfyejlanwz2spse2tp0tp9mngq8y2x7g")
+
+        let metadata = try XCTUnwrap(decodedMetadata(from: shareableEventCoordinates))
+        XCTAssertNil(metadata.eventId)
+        XCTAssertEqual(metadata.identifier, "")
+        XCTAssertEqual(metadata.pubkey, event.pubkey)
+        XCTAssertNil(metadata.kind)
+        XCTAssertEqual(metadata.relays, [])
+    }
+
+}

--- a/Tests/NostrSDKTests/Events/NostrEventTests.swift
+++ b/Tests/NostrSDKTests/Events/NostrEventTests.swift
@@ -8,7 +8,7 @@
 @testable import NostrSDK
 import XCTest
 
-final class NostrEventTests: XCTestCase, FixtureLoading {
+final class NostrEventTests: XCTestCase, FixtureLoading, MetadataCoding {
 
     func testEquatable() throws {
         let textNoteEvent: TextNoteEvent = try decodeFixture(filename: "text_note")
@@ -42,6 +42,30 @@ final class NostrEventTests: XCTestCase, FixtureLoading {
 
         XCTAssertEqual(textNoteEvent.hashValue, nostrEvent.hashValue)
         XCTAssertNotEqual(nostrEvent.hashValue, differentEvent.hashValue)
+    }
+
+    func testBech32NoteId() throws {
+        let textNoteEvent: TextNoteEvent = try decodeFixture(filename: "text_note")
+        let bech32NoteId = textNoteEvent.bech32NoteId
+        XCTAssertEqual(bech32NoteId, "note1lf0dsn7ga6u4nlfe4k8yswyvlseswkv3a789qpjvlnk0myvthydshz7qeg")
+    }
+
+    func testShareableEventIdentifier() throws {
+        let relay1 = "wss://relay1.com"
+        let relay2 = "wss://relay2.com"
+
+        let textNoteEvent: TextNoteEvent = try decodeFixture(filename: "text_note")
+        let shareableEventIdentifier = try XCTUnwrap(textNoteEvent.shareableEventIdentifier(relayURLStrings: [relay1, relay2]))
+        XCTAssertEqual(shareableEventIdentifier, "nevent1qqs05hkcflywaw2el5u6mrjg8zx0cvc8txg7lrjsqex0em8ajx9mjxcpzpmhxue69uhhyetvv9unztnrdakszyrhwden5te0wfjkcctexghxxmmdqgsgydql3q4ka27d9wnlrmus4tvkrnc8ftc4h8h5fgyln54gl0a7dgsrqsqqqqqplcac7m")
+
+        let metadata = try XCTUnwrap(decodedMetadata(from: shareableEventIdentifier))
+        XCTAssertEqual(metadata.eventId, textNoteEvent.id)
+        XCTAssertNil(metadata.identifier)
+        XCTAssertEqual(metadata.pubkey, textNoteEvent.pubkey)
+        XCTAssertEqual(metadata.kind, UInt32(textNoteEvent.kind.rawValue))
+        XCTAssertEqual(metadata.relays?.count, 2)
+        XCTAssertEqual(metadata.relays?[0], relay1)
+        XCTAssertEqual(metadata.relays?[1], relay2)
     }
 
 }

--- a/Tests/NostrSDKTests/Events/ParameterizedReplaceableEventTests.swift
+++ b/Tests/NostrSDKTests/Events/ParameterizedReplaceableEventTests.swift
@@ -1,0 +1,77 @@
+//
+//  ParameterizedReplaceableEventTests.swift
+//
+//
+//  Created by Terry Yiu on 6/30/24.
+//
+
+@testable import NostrSDK
+import XCTest
+
+final class ParameterizedReplaceableEventTests: XCTestCase, FixtureLoading, MetadataCoding {
+
+    func testReplaceableEventCoordinates() throws {
+        let event: LongformContentEvent = try decodeFixture(filename: "longform")
+        let publicKey = try XCTUnwrap(PublicKey(hex: event.pubkey))
+        let expectedReplaceableEventCoordinates = try XCTUnwrap(EventCoordinates(kind: .longformContent, pubkey: publicKey, identifier: event.identifier))
+        XCTAssertEqual(event.replaceableEventCoordinates(relayURL: nil), expectedReplaceableEventCoordinates)
+    }
+
+    func testShareableEventCoordinates() throws {
+        let event: LongformContentEvent = try decodeFixture(filename: "longform")
+        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates())
+        XCTAssertEqual(shareableEventCoordinates, "naddr1qq25vwznf9yj63e4f3z82m2ytfnhs36r2eg4xq3qwjyk3rq9hdepztwc9420m0exhd0s8cw7fr5hscwcln3ffgh3d9rqxpqqqp65wj0jelr")
+
+        let metadata = try XCTUnwrap(decodedMetadata(from: shareableEventCoordinates))
+        XCTAssertNil(metadata.eventId)
+        XCTAssertEqual(metadata.identifier, event.identifier)
+        XCTAssertEqual(metadata.pubkey, event.pubkey)
+        XCTAssertEqual(metadata.kind, UInt32(event.kind.rawValue))
+        XCTAssertEqual(metadata.relays, [])
+    }
+
+    func testShareableEventCoordinatesWithRelays() throws {
+        let relay1 = "wss://relay1.com"
+        let relay2 = "wss://relay2.com"
+
+        let event: LongformContentEvent = try decodeFixture(filename: "longform")
+        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(relayURLStrings: [relay1, relay2]))
+        XCTAssertEqual(shareableEventCoordinates, "naddr1qq25vwznf9yj63e4f3z82m2ytfnhs36r2eg4xqgswaehxw309aex2mrp0ycjucm0d5q3qamnwvaz7tmjv4kxz7fj9e3k7mgzyp6gj6yvqkahyyfdmqk4fldly6a47qlpmeywj7rpmr7w999z7955vqcyqqq823cgq7hnn")
+
+        let metadata = try XCTUnwrap(decodedMetadata(from: shareableEventCoordinates))
+        XCTAssertNil(metadata.eventId)
+        XCTAssertEqual(metadata.identifier, event.identifier)
+        XCTAssertEqual(metadata.pubkey, event.pubkey)
+        XCTAssertEqual(metadata.kind, UInt32(event.kind.rawValue))
+        XCTAssertEqual(metadata.relays?.count, 2)
+        XCTAssertEqual(metadata.relays?[0], relay1)
+        XCTAssertEqual(metadata.relays?[1], relay2)
+    }
+
+    func testShareableEventCoordinatesExcludeAuthor() throws {
+        let event: LongformContentEvent = try decodeFixture(filename: "longform")
+        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(excludeAuthor: true))
+        XCTAssertEqual(shareableEventCoordinates, "naddr1qq25vwznf9yj63e4f3z82m2ytfnhs36r2eg4xqcyqqq823cn0tk0s")
+
+        let metadata = try XCTUnwrap(decodedMetadata(from: shareableEventCoordinates))
+        XCTAssertNil(metadata.eventId)
+        XCTAssertEqual(metadata.identifier, event.identifier)
+        XCTAssertNil(metadata.pubkey)
+        XCTAssertEqual(metadata.kind, UInt32(event.kind.rawValue))
+        XCTAssertEqual(metadata.relays, [])
+    }
+
+    func testShareableEventCoordinatesExcludeKind() throws {
+        let event: LongformContentEvent = try decodeFixture(filename: "longform")
+        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(excludeKind: true))
+        XCTAssertEqual(shareableEventCoordinates, "naddr1qq25vwznf9yj63e4f3z82m2ytfnhs36r2eg4xq3qwjyk3rq9hdepztwc9420m0exhd0s8cw7fr5hscwcln3ffgh3d9rqncjtcg")
+
+        let metadata = try XCTUnwrap(decodedMetadata(from: shareableEventCoordinates))
+        XCTAssertNil(metadata.eventId)
+        XCTAssertEqual(metadata.identifier, event.identifier)
+        XCTAssertEqual(metadata.pubkey, event.pubkey)
+        XCTAssertNil(metadata.kind)
+        XCTAssertEqual(metadata.relays, [])
+    }
+
+}

--- a/Tests/NostrSDKTests/Events/ParameterizedReplaceableEventTests.swift
+++ b/Tests/NostrSDKTests/Events/ParameterizedReplaceableEventTests.swift
@@ -50,7 +50,7 @@ final class ParameterizedReplaceableEventTests: XCTestCase, FixtureLoading, Meta
 
     func testShareableEventCoordinatesExcludeAuthor() throws {
         let event: LongformContentEvent = try decodeFixture(filename: "longform")
-        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(excludeAuthor: true))
+        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(includeAuthor: false))
         XCTAssertEqual(shareableEventCoordinates, "naddr1qq25vwznf9yj63e4f3z82m2ytfnhs36r2eg4xqcyqqq823cn0tk0s")
 
         let metadata = try XCTUnwrap(decodedMetadata(from: shareableEventCoordinates))
@@ -63,7 +63,7 @@ final class ParameterizedReplaceableEventTests: XCTestCase, FixtureLoading, Meta
 
     func testShareableEventCoordinatesExcludeKind() throws {
         let event: LongformContentEvent = try decodeFixture(filename: "longform")
-        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(excludeKind: true))
+        let shareableEventCoordinates = try XCTUnwrap(event.shareableEventCoordinates(includeKind: false))
         XCTAssertEqual(shareableEventCoordinates, "naddr1qq25vwznf9yj63e4f3z82m2ytfnhs36r2eg4xq3qwjyk3rq9hdepztwc9420m0exhd0s8cw7fr5hscwcln3ffgh3d9rqncjtcg")
 
         let metadata = try XCTUnwrap(decodedMetadata(from: shareableEventCoordinates))

--- a/Tests/NostrSDKTests/MetadataCodingTests.swift
+++ b/Tests/NostrSDKTests/MetadataCodingTests.swift
@@ -66,7 +66,31 @@ class MetadataCodingTests: XCTestCase, MetadataCoding {
         XCTAssertEqual(metadata.identifier, "1700730909108")
         XCTAssertEqual(metadata.kind, 30023)
     }
-    
+
+    func testNpubPrefixDecoding() throws {
+        let id = Keypair.test.publicKey.npub
+        let (hrp, _) = try Bech32.decode(id)
+        XCTAssertEqual(hrp, "npub")
+
+        XCTAssertThrowsError(try decodedMetadata(from: id))
+    }
+
+    func testNsecPrefixDecoding() throws {
+        let id = Keypair.test.privateKey.nsec
+        let (hrp, _) = try Bech32.decode(id)
+        XCTAssertEqual(hrp, "nsec")
+
+        XCTAssertThrowsError(try decodedMetadata(from: id))
+    }
+
+    func testNotePrefixDecoding() throws {
+        let id = "note1lf0dsn7ga6u4nlfe4k8yswyvlseswkv3a789qpjvlnk0myvthydshz7qeg"
+        let (hrp, _) = try Bech32.decode(id)
+        XCTAssertEqual(hrp, "note")
+
+        XCTAssertThrowsError(try decodedMetadata(from: id))
+    }
+
     func testIgnoreUnrecognizedType() throws {
         // start with the pubkey (type is "00", length is "20", the rest is the pubkey)
         var tlvString = "00203bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"
@@ -151,5 +175,40 @@ class MetadataCodingTests: XCTestCase, MetadataCoding {
         let identifier = try encodedIdentifier(with: metadata, identifierType: .address)
         let expected = "naddr1qqxnzdesxqmnxvpexqunzvpcqyt8wumn8ghj7un9d3shjtnwdaehgu3wvfskueqzypve7elhmamff3sr5mgxxms4a0rppkmhmn7504h96pfcdkpplvl2jqcyqqq823cnmhuld"
         XCTAssertEqual(identifier, expected)
+    }
+
+    func testNpubEncoding() throws {
+        var metadata = Metadata()
+        metadata.pubkey = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"
+
+        metadata.relays = [
+            "wss://r.x.com",
+            "wss://djbas.sadkb.com"
+        ]
+
+        XCTAssertThrowsError(try encodedIdentifier(with: metadata, identifierType: .publicKey))
+    }
+
+    func testNsecEncoding() throws {
+        var metadata = Metadata()
+        metadata.pubkey = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"
+
+        metadata.relays = [
+            "wss://r.x.com",
+            "wss://djbas.sadkb.com"
+        ]
+
+        XCTAssertThrowsError(try encodedIdentifier(with: metadata, identifierType: .privateKey))
+    }
+
+    func testNoteEncoding() throws {
+        var metadata = Metadata()
+        metadata.eventId = "b9f5441e45ca39179320e0031cfb18e34078673dcc3d3e3a3b3a981760aa5696"
+        metadata.relays = [
+            "wss://nostr-relay.untethr.me",
+            "wss://nostr-pub.wellorder.net"
+        ]
+
+        XCTAssertThrowsError(try encodedIdentifier(with: metadata, identifierType: .note))
     }
 }


### PR DESCRIPTION
https://github.com/nostr-protocol/nips/blob/master/19.md

This change enables clients to generate shareable identifiers easily for human consumption.

I also refactored the `npub` and `nsec` bech32 prefixes into the `Bech32IdentifierType` enum.