### PR TITLE
Make properties of Tag public

### DIFF
--- a/Sources/NostrSDK/Tag.swift
+++ b/Sources/NostrSDK/Tag.swift
@@ -68,15 +68,15 @@ public class Tag: Codable, Equatable, Hashable {
     }
     
     /// The name of the tag.
-    let name: String
+    public let name: String
 
     /// The main value associated with the tag. For example, for the
     /// pubkey name, the `value` is the 32-byte, hex-encoded pubkey.
-    let value: String
-    
+    public let value: String
+
     /// The remaining parameters in the array of strings the tag consists of.
-    let otherParameters: [String]
-    
+    public let otherParameters: [String]
+
     /// Creates and returns a ``Tag`` object that references some piece of content.
     /// - Parameters:
     ///   - name: The name of the tag.


### PR DESCRIPTION
Clients need to access these Tag properties because referring to tag values are an essential part of the fundamental Nostr data structures.