### PR TITLE
Fix GitHub workflows to trigger on pull_request_target so that they can run on PRs from public forks

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -3,6 +3,8 @@ name: SwiftLint
 on:
   push:
     branches: [ '**' ]
+  pull_request_target:
+    branches: [ '**' ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -3,6 +3,8 @@ name: Unit Tests
 on:
   push:
     branches: [ '**' ]
+  pull_request_target:
+    branches: [ '**' ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
As an example, I could not properly merge https://github.com/nostr-sdk/nostr-sdk-ios/pull/171 because the workflows were not running. I had to temporarily remove the merge restrictions to move ahead.