### PR TITLE
Add NostrEventBuilding protocol to enable flexible composition of shared patterns across different kinds of NostrEvents

### DIFF
--- a/Sources/NostrSDK/CustomEmoji.swift
+++ b/Sources/NostrSDK/CustomEmoji.swift
@@ -39,6 +39,16 @@ public class CustomEmoji: CustomEmojiValidating, Equatable {
     }
 }
 
+/// Builder that adds ``CustomEmoji``s to a ``NostrEvent``.
+public protocol CustomEmojiBuilding: NostrEventBuilding {}
+public extension CustomEmojiBuilding {
+    /// Adds a list of ``CustomEmoji``.
+    @discardableResult
+    func customEmojis(_ customEmojis: [CustomEmoji]) -> Self {
+        appendTags(contentsOf: customEmojis.map { $0.tag })
+    }
+}
+
 public protocol CustomEmojiInterpreting: NostrEvent, CustomEmojiValidating {}
 public extension CustomEmojiInterpreting {
     /// Returns the list of well-formatted custom emojis derived from NostrEvent tags.

--- a/Sources/NostrSDK/Events/AuthenticationEvent.swift
+++ b/Sources/NostrSDK/Events/AuthenticationEvent.swift
@@ -17,8 +17,18 @@ public final class AuthenticationEvent: NostrEvent, RelayProviding {
     }
 
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
     }
 
     init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {

--- a/Sources/NostrSDK/Events/BookmarksListEvent.swift
+++ b/Sources/NostrSDK/Events/BookmarksListEvent.swift
@@ -16,10 +16,20 @@ public final class BookmarksListEvent: NostrEvent, HashtagInterpreting, PrivateT
     }
     
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }
-    
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
+    }
+
     init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: .bookmarksList, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }

--- a/Sources/NostrSDK/Events/Calendars/CalendarEventRSVP.swift
+++ b/Sources/NostrSDK/Events/Calendars/CalendarEventRSVP.swift
@@ -16,8 +16,18 @@ public final class CalendarEventRSVP: NostrEvent, ParameterizedReplaceableEvent 
     }
 
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
     }
 
     public init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {

--- a/Sources/NostrSDK/Events/Calendars/CalendarListEvent.swift
+++ b/Sources/NostrSDK/Events/Calendars/CalendarListEvent.swift
@@ -18,8 +18,18 @@ public final class CalendarListEvent: NostrEvent, ParameterizedReplaceableEvent,
     }
 
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
     }
 
     public init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {

--- a/Sources/NostrSDK/Events/Calendars/DateBasedCalendarEvent.swift
+++ b/Sources/NostrSDK/Events/Calendars/DateBasedCalendarEvent.swift
@@ -16,8 +16,18 @@ public final class DateBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     }
 
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
     }
 
     public init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {

--- a/Sources/NostrSDK/Events/Calendars/TimeBasedCalendarEvent.swift
+++ b/Sources/NostrSDK/Events/Calendars/TimeBasedCalendarEvent.swift
@@ -14,8 +14,18 @@ public final class TimeBasedCalendarEvent: NostrEvent, CalendarEventInterpreting
     }
 
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
     }
 
     public init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {

--- a/Sources/NostrSDK/Events/DeletionEvent.swift
+++ b/Sources/NostrSDK/Events/DeletionEvent.swift
@@ -18,10 +18,20 @@ public final class DeletionEvent: NostrEvent, EventCoordinatesTagInterpreting {
     }
     
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }
-    
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
+    }
+
     init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: .deletion, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }

--- a/Sources/NostrSDK/Events/FollowListEvent.swift
+++ b/Sources/NostrSDK/Events/FollowListEvent.swift
@@ -37,10 +37,20 @@ public final class FollowListEvent: NostrEvent, NonParameterizedReplaceableEvent
     }
     
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }
-    
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
+    }
+
     init(tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: .followList, content: "", tags: tags, createdAt: createdAt, signedBy: keypair)
     }

--- a/Sources/NostrSDK/Events/GenericRepostEvent.swift
+++ b/Sources/NostrSDK/Events/GenericRepostEvent.swift
@@ -17,10 +17,20 @@ public class GenericRepostEvent: NostrEvent {
     }
     
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }
-    
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
+    }
+
     init(content: String, tags: [Tag], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: Self.kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }

--- a/Sources/NostrSDK/Events/GiftWrap/GiftWrapEvent.swift
+++ b/Sources/NostrSDK/Events/GiftWrap/GiftWrapEvent.swift
@@ -22,8 +22,18 @@ public final class GiftWrapEvent: NostrEvent, NIP44v2Encrypting {
     }
 
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
     }
 
     public init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970 - TimeInterval.random(in: 0...172800)), signedBy keypair: Keypair) throws {

--- a/Sources/NostrSDK/Events/GiftWrap/SealEvent.swift
+++ b/Sources/NostrSDK/Events/GiftWrap/SealEvent.swift
@@ -23,8 +23,18 @@ public final class SealEvent: NostrEvent, NIP44v2Encrypting {
     }
 
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
     }
 
     public init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970 - TimeInterval.random(in: 0...172800)), signedBy keypair: Keypair) throws {

--- a/Sources/NostrSDK/Events/LegacyEncryptedDirectMessageEvent.swift
+++ b/Sources/NostrSDK/Events/LegacyEncryptedDirectMessageEvent.swift
@@ -19,10 +19,20 @@ public final class LegacyEncryptedDirectMessageEvent: NostrEvent, LegacyDirectMe
     }
     
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }
-    
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
+    }
+
     init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: .legacyEncryptedDirectMessage, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }

--- a/Sources/NostrSDK/Events/LongformContentEvent.swift
+++ b/Sources/NostrSDK/Events/LongformContentEvent.swift
@@ -20,10 +20,20 @@ public final class LongformContentEvent: NostrEvent, HashtagInterpreting, Parame
     }
     
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }
-    
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
+    }
+
     init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: .longformContent, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }

--- a/Sources/NostrSDK/Events/MuteListEvent.swift
+++ b/Sources/NostrSDK/Events/MuteListEvent.swift
@@ -16,10 +16,20 @@ public final class MuteListEvent: NostrEvent, HashtagInterpreting, PrivateTagInt
     }
     
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }
-    
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
+    }
+
     init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: .muteList, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }

--- a/Sources/NostrSDK/Events/ReactionEvent.swift
+++ b/Sources/NostrSDK/Events/ReactionEvent.swift
@@ -17,10 +17,20 @@ public class ReactionEvent: NostrEvent, CustomEmojiInterpreting {
     }
     
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }
-    
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
+    }
+
     init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: .reaction, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }

--- a/Sources/NostrSDK/Events/RelayListMetadataEvent.swift
+++ b/Sources/NostrSDK/Events/RelayListMetadataEvent.swift
@@ -27,8 +27,18 @@ public final class RelayListMetadataEvent: NostrEvent, NonParameterizedReplaceab
     }
 
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
     }
 
     init(tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {

--- a/Sources/NostrSDK/Events/ReportEvent.swift
+++ b/Sources/NostrSDK/Events/ReportEvent.swift
@@ -35,10 +35,20 @@ public final class ReportEvent: NostrEvent {
     }
     
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }
-    
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
+    }
+
     public init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: .report, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }

--- a/Sources/NostrSDK/Events/TextNoteEvent.swift
+++ b/Sources/NostrSDK/Events/TextNoteEvent.swift
@@ -15,16 +15,27 @@ public final class TextNoteEvent: NostrEvent, CustomEmojiInterpreting {
     public required init(from decoder: Decoder) throws {
         try super.init(from: decoder)
     }
-    
+
     @available(*, unavailable, message: "This initializer is unavailable for this class.")
-    override init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
+    override init(id: String, pubkey: String, createdAt: Int64, kind: EventKind, tags: [Tag], content: String, signature: String?) {
+        super.init(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: signature)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), pubkey: String) {
+        super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, pubkey: pubkey)
+    }
+
+    @available(*, unavailable, message: "This initializer is unavailable for this class.")
+    required init(kind: EventKind, content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: kind, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }
-    
+
+    @available(*, deprecated, message: "Deprecated in favor of TextNote.Builder.")
     init(content: String, tags: [Tag] = [], createdAt: Int64 = Int64(Date.now.timeIntervalSince1970), signedBy keypair: Keypair) throws {
         try super.init(kind: .textNote, content: content, tags: tags, createdAt: createdAt, signedBy: keypair)
     }
-    
+
     /// Pubkeys mentioned in the note content.
     public var mentionedPubkeys: [String] {
         allValues(forTagName: .pubkey)
@@ -131,66 +142,102 @@ public extension EventCreating {
     ///
     /// See [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md)
     /// See [NIP-10 - On "e" and "p" tags in Text Events (kind 1)](https://github.com/nostr-protocol/nips/blob/master/10.md)
+    @available(*, deprecated, message: "Deprecated in favor of TextNote.Builder.")
     func textNote(withContent content: String, replyingTo repliedEvent: TextNoteEvent? = nil, mentionedEventTags: [EventTag]? = nil, subject: String? = nil, customEmojis: [CustomEmoji]? = nil, signedBy keypair: Keypair) throws -> TextNoteEvent {
+
+        let builder = try TextNoteEvent.Builder()
+            .content(content)
+            .repliedEvent(repliedEvent)
+            .subject(subject)
+
+        if let customEmojis {
+            builder.customEmojis(customEmojis)
+        }
+
         if let mentionedEventTags {
+            try builder.mentionedEventTags(mentionedEventTags)
+        }
+
+        return try builder.build(signedBy: keypair)
+    }
+}
+
+public extension TextNoteEvent {
+    /// Builder of a ``TextNoteEvent``.
+    final class Builder: NostrEvent.Builder<TextNoteEvent>, CustomEmojiBuilding {
+        public init() {
+            super.init(kind: .textNote)
+        }
+
+        /// Sets the ``TextNoteEvent`` that is being replied to from this text note that is being built.
+        @discardableResult
+        public final func repliedEvent(_ repliedEvent: TextNoteEvent?) throws -> Self {
+            guard let repliedEvent else {
+                return self
+            }
+
+            guard let rootEventTag = repliedEvent.rootEventTag else {
+                throw EventCreatingError.invalidInput
+            }
+
+            // Maximize backwards compatibility with NIP-10 deprecated positional event tags
+            // by ensuring ordering of types of event tags.
+
+            // Root tag comes first.
+            if rootEventTag.marker == .root {
+                insertTags(rootEventTag.tag, at: 0)
+            } else {
+                // Recreate the event tag with a root marker if the one being read does not have a marker.
+                let rootEventTagWithMarker = try EventTag(eventId: rootEventTag.eventId, relayURL: rootEventTag.relayURL, marker: .root)
+                insertTags(rootEventTagWithMarker.tag, at: 0)
+            }
+
+            // Reply tag comes last.
+            appendTags(try EventTag(eventId: repliedEvent.id, marker: .reply).tag)
+
+            // When replying to a text event E, the reply event's "p" tags should contain all of E's "p" tags as well as the "pubkey" of the event being replied to.
+            // Example: Given a text event authored by a1 with "p" tags [p1, p2, p3] then the "p" tags of the reply should be [a1, p1, p2, p3] in no particular order.
+            appendTags(contentsOf: repliedEvent.tags.filter { $0.name == TagName.pubkey.rawValue })
+
+            // Add the author "p" tag if it was not already added.
+            if !tags.contains(where: { $0.name == TagName.pubkey.rawValue && $0.value == repliedEvent.pubkey }) {
+                appendTags(Tag(name: .pubkey, value: repliedEvent.pubkey))
+            }
+
+            return self
+        }
+
+        /// Sets the list of events, represented by ``EventTag``, that are mentioned from this text note that is being built.
+        @discardableResult
+        public final func mentionedEventTags(_ mentionedEventTags: [EventTag]) throws -> Builder {
+            guard !mentionedEventTags.isEmpty else {
+                return self
+            }
+
             guard mentionedEventTags.allSatisfy({ $0.marker == .mention }) else {
                 throw EventCreatingError.invalidInput
             }
-        }
 
-        var tags: [Tag] = []
-
-        if let repliedEvent {
-            if let rootEventTag = repliedEvent.rootEventTag {
-                // Maximize backwards compatibility with NIP-10 deprecated positional event tags
-                // by ensuring ordering of types of event tags.
-
-                // 1. Root tag comes first.
-                if rootEventTag.marker == .root {
-                    tags.append(rootEventTag.tag)
-                } else {
-                    // Recreate the event tag with a root marker if the one being read does not have a marker.
-                    let rootEventTagWithMarker = try EventTag(eventId: rootEventTag.eventId, relayURL: rootEventTag.relayURL, marker: .root)
-                    tags.append(rootEventTagWithMarker.tag)
-                }
-
-                // 2. Mentions go in between.
-                if let mentionedEventTags {
-                    tags += mentionedEventTags.map { $0.tag }
-                }
-
-                // 3. Reply tag comes last.
-                tags.append(try EventTag(eventId: repliedEvent.id, marker: .reply).tag)
-
-                // When replying to a text event E, the reply event's "p" tags should contain all of E's "p" tags as well as the "pubkey" of the event being replied to.
-                // Example: Given a text event authored by a1 with "p" tags [p1, p2, p3] then the "p" tags of the reply should be [a1, p1, p2, p3] in no particular order.
-                tags += repliedEvent.tags.filter { $0.name == TagName.pubkey.rawValue }
-
-                // Add the author "p" tag if it was not already added.
-                if !tags.contains(where: { $0.name == TagName.pubkey.rawValue && $0.value == repliedEvent.pubkey }) {
-                    tags.append(Tag(name: .pubkey, value: repliedEvent.pubkey))
-                }
+            let newTags = mentionedEventTags.map { $0.tag }
+            // Mentions go in between root markers and reply markers.
+            if let replyMarkerIndex = tags.firstIndex(where: { $0.otherParameters[1] == EventTagMarker.reply.rawValue }) {
+                insertTags(contentsOf: newTags, at: replyMarkerIndex)
             } else {
-                if let mentionedEventTags {
-                    tags += mentionedEventTags.map { $0.tag }
-                }
-
-                // If the event being replied to has no root marker event tag,
-                // the event being replied to is the root.
-                tags.append(try EventTag(eventId: repliedEvent.id, marker: .root).tag)
+                appendTags(contentsOf: newTags)
             }
-        } else if let mentionedEventTags {
-            tags += mentionedEventTags.map { $0.tag }
+
+            return self
         }
 
-        if let customEmojis {
-            tags += customEmojis.map { $0.tag }
-        }
+        /// Sets the subject for this text note.
+        @discardableResult
+        public final func subject(_ subject: String?) -> Builder {
+            guard let subject else {
+                return self
+            }
 
-        if let subject {
-            tags.append(Tag(name: .subject, value: subject))
+            appendTags(Tag(name: .subject, value: subject))
+            return self
         }
-
-        return try TextNoteEvent(content: content, tags: tags, signedBy: keypair)
     }
 }

--- a/Tests/NostrSDKTests/Events/GiftWrap/GiftWrapEventTests.swift
+++ b/Tests/NostrSDKTests/Events/GiftWrap/GiftWrapEventTests.swift
@@ -26,7 +26,9 @@ final class GiftWrapEventTests: XCTestCase, EventCreating, EventVerifying, Fixtu
     }
 
     func testCreateGiftWrapFailsWithSignedEvent() throws {
-        let signedEvent = try textNote(withContent: "Are you going to the party tonight?", signedBy: .test)
+        let signedEvent = try TextNoteEvent.Builder()
+            .content("Are you going to the party tonight?")
+            .build(signedBy: .test)
         XCTAssertThrowsError(try giftWrap(withRumor: signedEvent, toRecipient: GiftWrapEventTests.recipient.publicKey, signedBy: .test))
     }
 

--- a/Tests/NostrSDKTests/Events/GiftWrap/RumorEventTests.swift
+++ b/Tests/NostrSDKTests/Events/GiftWrap/RumorEventTests.swift
@@ -11,7 +11,25 @@ import XCTest
 final class RumorEventTests: XCTestCase, EventCreating, EventVerifying, FixtureLoading {
 
     func testCreateRumor() throws {
-        let signedEvent = try textNote(withContent: "Are you going to the party tonight?", signedBy: .test)
+        let signedEvent = TextNoteEvent.Builder()
+            .content("Are you going to the party tonight?")
+            .build(pubkey: Keypair.test.publicKey)
+        let rumor = signedEvent.rumor
+
+        XCTAssertEqual(rumor.pubkey, Keypair.test.publicKey.hex)
+        XCTAssertEqual(rumor.kind, .textNote)
+        XCTAssertEqual(rumor.tags, [])
+        XCTAssertNil(rumor.signature)
+        XCTAssertTrue(rumor.isRumor)
+        XCTAssertEqual(rumor.content, "Are you going to the party tonight?")
+
+        XCTAssertThrowsError(try verifyEvent(rumor))
+    }
+
+    func testCreateRumorFromSignedEvent() throws {
+        let signedEvent = try TextNoteEvent.Builder()
+            .content("Are you going to the party tonight?")
+            .build(signedBy: .test)
         let rumor = signedEvent.rumor
 
         XCTAssertEqual(rumor.pubkey, Keypair.test.publicKey.hex)

--- a/Tests/NostrSDKTests/Events/GiftWrap/SealEventTests.swift
+++ b/Tests/NostrSDKTests/Events/GiftWrap/SealEventTests.swift
@@ -26,7 +26,9 @@ final class SealEventTests: XCTestCase, EventCreating, EventVerifying, FixtureLo
     }
 
     func testCreateSealFailsWithSignedEvent() throws {
-        let signedEvent = try textNote(withContent: "Are you going to the party tonight?", signedBy: .test)
+        let signedEvent = try TextNoteEvent.Builder()
+            .content("Are you going to the party tonight?")
+            .build(signedBy: .test)
         XCTAssertThrowsError(try seal(withRumor: signedEvent, toRecipient: SealEventTests.recipient.publicKey, signedBy: .test))
     }
 

--- a/Tests/NostrSDKTests/Events/ReactionEventTests.swift
+++ b/Tests/NostrSDKTests/Events/ReactionEventTests.swift
@@ -11,11 +11,12 @@ import XCTest
 final class ReactionEventTests: XCTestCase, EventCreating, EventVerifying, FixtureLoading {
 
     func testCreateReactionEvent() throws {
-        let reactedEvent = try textNote(withContent: "Hello world!",
-                                signedBy: Keypair.test)
+        let reactedEvent = try TextNoteEvent.Builder()
+            .content("Hello world!")
+            .build(signedBy: Keypair.test)
         let event = try reaction(withContent: "🤙",
                                  reactedEvent: reactedEvent,
-                                 signedBy: Keypair.test)
+                                 signedBy: .test)
 
         XCTAssertEqual(event.kind, .reaction)
         XCTAssertEqual(event.pubkey, Keypair.test.publicKey.hex)
@@ -33,15 +34,15 @@ final class ReactionEventTests: XCTestCase, EventCreating, EventVerifying, Fixtu
     }
 
     func testCreateCustomEmojiReactionEvent() throws {
-        let reactedEvent = try textNote(withContent: "Hello world!",
-                                signedBy: Keypair.test)
+        let reactedEvent = try TextNoteEvent.Builder()
+            .build(signedBy: .test)
 
         let imageURLString = "https://nostrsdk.com/ostrich.png"
         let imageURL = try XCTUnwrap(URL(string: imageURLString))
         let customEmoji = try XCTUnwrap(CustomEmoji(shortcode: "ostrich", imageURL: imageURL))
         let event = try reaction(withCustomEmoji: customEmoji,
                                  reactedEvent: reactedEvent,
-                                 signedBy: Keypair.test)
+                                 signedBy: .test)
 
         XCTAssertEqual(event.kind, .reaction)
         XCTAssertEqual(event.pubkey, Keypair.test.publicKey.hex)


### PR DESCRIPTION
https://github.com/nostr-sdk/nostr-sdk-ios/issues/170

This PR uses a combination of different patterns (builder, inheritance, protocols, generics) to enable what I think is a flexible, powerful, easy-to-use framework to build NostrEvents.

It allows maintainers of the SDK to compose shared logic / components together, e.g. NIPs that are used in multiple event kinds. Duplicate code no longer needs to be copied into multiple `EventCreating` functions.

It allows developers using the SDK to build NostrEvents of any event kind, even if it is not yet supported in the SDK. They can make additions on top of what the SDK provides, or construct their own custom event. They can also not be constrained to what I believe in my opinion is a rigid `EventCreating` protocol API, where they need to pass in too many parameters into one single function just to be able to create the NostrEvent that they want.

I'm proposing we eventually deprecate the `EventCreating` protocol in favor of this `NostrEventBuilding` protocol.

Note: for full transparency, I tried to integrate Apple's [result builder](https://developer.apple.com/videos/play/wwdc2021/10253/) pattern unsuccessfully. Although it's more idiomatic to the Swift language, I actually found it to be extremely difficult to implement for this use case. It's too rigid to allow for subclassing and composability. It also constrains you to build your object within a single block. Lastly, error handling was quite difficult. You have to do some really weird things to bubble errors up the stack to the caller.