### PR TITLE
Add referencedPubkeys, referencedEventIds, and referencedEventCoordinates to NostrEvent

### DIFF
--- a/Sources/NostrSDK/Events/BookmarksListEvent.swift
+++ b/Sources/NostrSDK/Events/BookmarksListEvent.swift
@@ -46,7 +46,7 @@ public final class BookmarksListEvent: NostrEvent, HashtagInterpreting, PrivateT
     
     /// Coordinates of bookmarked articles.
     public var articlesCoordinates: [EventCoordinates] {
-        eventCoordinates
+        referencedEventCoordinates
     }
     
     /// Bookmarked links (web URLs).

--- a/Sources/NostrSDK/Events/Calendars/CalendarEventRSVP.swift
+++ b/Sources/NostrSDK/Events/Calendars/CalendarEventRSVP.swift
@@ -36,7 +36,7 @@ public final class CalendarEventRSVP: NostrEvent, ParameterizedReplaceableEvent 
 
     /// Event coordinates to the calendar event this RSVP responds to.
     public var calendarEventCoordinates: EventCoordinates? {
-        tags.compactMap { EventCoordinates(eventCoordinatesTag: $0) }
+        referencedEventCoordinates
             .first { $0.kind == .dateBasedCalendarEvent || $0.kind == .timeBasedCalendarEvent }
     }
 

--- a/Sources/NostrSDK/Events/Calendars/CalendarListEvent.swift
+++ b/Sources/NostrSDK/Events/Calendars/CalendarListEvent.swift
@@ -38,7 +38,7 @@ public final class CalendarListEvent: NostrEvent, ParameterizedReplaceableEvent,
 
     /// The event coordinates of the calendar events that belong to this calendar.
     public var calendarEventCoordinateList: [EventCoordinates] {
-        tags.compactMap { EventCoordinates(eventCoordinatesTag: $0) }
+        referencedEventCoordinates
             .filter { $0.kind == .dateBasedCalendarEvent || $0.kind == .timeBasedCalendarEvent }
     }
 }

--- a/Sources/NostrSDK/Events/NostrEvent.swift
+++ b/Sources/NostrSDK/Events/NostrEvent.swift
@@ -135,6 +135,21 @@ public class NostrEvent: Codable, Equatable, Hashable {
         NostrEvent(id: id, pubkey: pubkey, createdAt: createdAt, kind: kind, tags: tags, content: content, signature: nil)
     }
 
+    /// Pubkeys referenced in this event.
+    public var referencedPubkeys: [String] {
+        allValues(forTagName: .pubkey)
+    }
+
+    /// Events referenced in this event.
+    public var referencedEventIds: [String] {
+        allValues(forTagName: .event)
+    }
+
+    /// Event coordinates referenced in this event.
+    public var referencedEventCoordinates: [EventCoordinates] {
+        tags.compactMap { EventCoordinates(eventCoordinatesTag: $0) }
+    }
+
     /// All tags with the provided name.
     public func allTags(withTagName tagName: TagName) -> [Tag] {
         tags.filter { $0.name == tagName.rawValue }

--- a/Sources/NostrSDK/Events/Tags/EventCoordinates.swift
+++ b/Sources/NostrSDK/Events/Tags/EventCoordinates.swift
@@ -123,11 +123,12 @@ public struct EventCoordinates: PubkeyProviding, RelayProviding, RelayURLValidat
     }
 }
 
+@available(*, deprecated, message: "Deprecated in favor of referencedEventCoordinates in NostrEvent.")
 public protocol EventCoordinatesTagInterpreting: NostrEvent {}
 public extension EventCoordinatesTagInterpreting {
     /// The referenced replaceable event tags of the event.
+    @available(*, deprecated, message: "Deprecated in favor of referencedEventCoordinates.")
     var eventCoordinates: [EventCoordinates] {
-        tags.filter { $0.name == TagName.eventCoordinates.rawValue }
-            .compactMap { EventCoordinates(eventCoordinatesTag: $0) }
+        referencedEventCoordinates
     }
 }

--- a/Sources/NostrSDK/Events/TextNoteEvent.swift
+++ b/Sources/NostrSDK/Events/TextNoteEvent.swift
@@ -42,20 +42,10 @@ public final class TextNoteEvent: NostrEvent, CustomEmojiInterpreting, ThreadedE
         referencedPubkeys
     }
 
-    /// Pubkeys referenced in the note content.
-    public var referencedPubkeys: [String] {
-        allValues(forTagName: .pubkey)
-    }
-
     /// Events referenced in the note content.
     @available(*, deprecated, message: "Deprecated in favor of referencedEventIds. Mention is an overloaded term from NIP-10.")
     public var mentionedEventIds: [String] {
         referencedEventIds
-    }
-
-    /// Events referenced in the note content.
-    public var referencedEventIds: [String] {
-        allValues(forTagName: .event)
     }
 
     /// a short subject for a text note, similar to subjects in emails.

--- a/Tests/NostrSDKTests/Events/DeletionEventTests.swift
+++ b/Tests/NostrSDKTests/Events/DeletionEventTests.swift
@@ -21,6 +21,7 @@ final class DeletionEventTests: XCTestCase, EventCreating, EventVerifying, Fixtu
 
         XCTAssertEqual(event.reason, "Didn't mean to post")
         XCTAssertEqual(event.deletedEventIds, ["fa5ed84fc8eeb959fd39ad8e48388cfc33075991ef8e50064cfcecfd918bb91b", "8f4b2477881ec73c824410610709163f6a4e8fda067de8c4bbd0a9e337901eac"])
+        XCTAssertTrue(event.referencedEventCoordinates.isEmpty)
         XCTAssertTrue(event.eventCoordinates.isEmpty)
 
         try verifyEvent(event)
@@ -43,6 +44,7 @@ final class DeletionEventTests: XCTestCase, EventCreating, EventVerifying, Fixtu
         XCTAssertEqual(event.kind, .deletion)
 
         XCTAssertEqual(event.reason, "Didn't mean to post")
+        XCTAssertEqual(event.referencedEventCoordinates, [longformNoteEventCoordinates])
         XCTAssertEqual(event.eventCoordinates, [longformNoteEventCoordinates])
         XCTAssertTrue(event.deletedEventIds.isEmpty)
 
@@ -71,6 +73,7 @@ final class DeletionEventTests: XCTestCase, EventCreating, EventVerifying, Fixtu
         XCTAssertEqual(event.content, "")
         XCTAssertEqual(event.signature, "f672f285ef3506509b6b12ffcfaf90f234ed9895894a989f9c7b69023b600dd0544b36edc81f0889928e637f53fe34444c62e82d4f5add46c5b7a283d02e207d")
 
+        XCTAssertEqual(event.referencedEventIds, ["69ba6336507d20f6673e5866be32583e0d0ae61a4149c04f2d48d124671e5aff"])
         XCTAssertEqual(event.mentionedEventIds, ["69ba6336507d20f6673e5866be32583e0d0ae61a4149c04f2d48d124671e5aff"])
     }
 


### PR DESCRIPTION
This PR deprecates the `EventCoordinatesTagInterpreting` protocol because:
1. [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md#tags) says that all event kinds can refer to addressable or replaceable events (i.e. reference event coordinates). I've added `referencedEventCoordinates` to `NostrEvent`.
2. It's unclear what `eventCoordinates` means. Is it referring to the coordinates of the event object itself or events it's referencing? (it's the latter)

[NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md#tags) also says that all event kinds can refer to other events or users, so I've added `referencedPubkeys` and `referencedEventIds` to `NostrEvent`.