### PR TITLE
Add nip44 encrypt/decrypt example to demo project

### DIFF
--- a/demo/NostrSDKDemo.xcodeproj/project.pbxproj
+++ b/demo/NostrSDKDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F73BD012D24432B00C49147 /* EncryptMessageDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F73BD002D24432B00C49147 /* EncryptMessageDemoView.swift */; };
+		1F73BD032D24491500C49147 /* DecryptMessageDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F73BD022D24491500C49147 /* DecryptMessageDemoView.swift */; };
 		3A114FB42B0178AB00ABDBB0 /* NostrSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 3A114FB32B0178AB00ABDBB0 /* NostrSDK */; };
 		3AA4CD712C06523D0060554E /* LegacyDirectMessageDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA4CD702C06523D0060554E /* LegacyDirectMessageDemoView.swift */; };
 		50BB70A12B4302F300EDD3B5 /* RelaysView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BB70A02B4302F300EDD3B5 /* RelaysView.swift */; };
@@ -24,6 +26,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1F73BD002D24432B00C49147 /* EncryptMessageDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncryptMessageDemoView.swift; sourceTree = "<group>"; };
+		1F73BD022D24491500C49147 /* DecryptMessageDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecryptMessageDemoView.swift; sourceTree = "<group>"; };
 		3AA4CD702C06523D0060554E /* LegacyDirectMessageDemoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegacyDirectMessageDemoView.swift; sourceTree = "<group>"; };
 		50BB70A02B4302F300EDD3B5 /* RelaysView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelaysView.swift; sourceTree = "<group>"; };
 		F78221C02A87FB39008D5AE8 /* ConnectRelayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectRelayView.swift; sourceTree = "<group>"; };
@@ -55,9 +59,11 @@
 		F78221BC2A87EF6C008D5AE8 /* Demo Views */ = {
 			isa = PBXGroup;
 			children = (
+				1F73BD022D24491500C49147 /* DecryptMessageDemoView.swift */,
+				1F73BD002D24432B00C49147 /* EncryptMessageDemoView.swift */,
+				F7CB36402A3ACD530098F35C /* GenerateKeyDemoView.swift */,
 				3AA4CD702C06523D0060554E /* LegacyDirectMessageDemoView.swift */,
 				F7CB36462A3B74380098F35C /* NIP05VerificationDemoView.swift */,
-				F7CB36402A3ACD530098F35C /* GenerateKeyDemoView.swift */,
 				F786D8F62A3BAED800A29915 /* QueryRelayDemoView.swift */,
 			);
 			path = "Demo Views";
@@ -205,6 +211,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F7CB362E2A35127B0098F35C /* ContentView.swift in Sources */,
+				1F73BD012D24432B00C49147 /* EncryptMessageDemoView.swift in Sources */,
 				F7CB362C2A35127B0098F35C /* NostrSDKDemoApp.swift in Sources */,
 				F7CB36472A3B74380098F35C /* NIP05VerificationDemoView.swift in Sources */,
 				F78221C42A8803F3008D5AE8 /* Helpers.swift in Sources */,
@@ -215,6 +222,7 @@
 				F78221CE2A8999F9008D5AE8 /* KeyInputSectionView.swift in Sources */,
 				F7CB36412A3ACD530098F35C /* GenerateKeyDemoView.swift in Sources */,
 				F7CB36432A3ACD7B0098F35C /* ListOptionView.swift in Sources */,
+				1F73BD032D24491500C49147 /* DecryptMessageDemoView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/demo/NostrSDKDemo/ContentView.swift
+++ b/demo/NostrSDKDemo/ContentView.swift
@@ -26,6 +26,14 @@ struct ContentView: View {
                                     AnyView(LegacyDirectMessageDemoView()),
                                    imageName: "list.bullet",
                                    labelText: "NIP-04 Direct Message")
+                    ListOptionView(destinationView:
+                                    AnyView(EncryptMessageDemoView()),
+                                   imageName: "list.bullet",
+                                   labelText: "NIP-44 Encrypt")
+                    ListOptionView(destinationView:
+                                    AnyView(DecryptMessageDemoView()),
+                                   imageName: "list.bullet",
+                                   labelText: "NIP-44 Decrypt")
                     ListOptionView(destinationView: AnyView(GenerateKeyDemoView()),
                                    imageName: "key",
                                    labelText: "Key Generation")

--- a/demo/NostrSDKDemo/Demo Views/DecryptMessageDemoView.swift
+++ b/demo/NostrSDKDemo/Demo Views/DecryptMessageDemoView.swift
@@ -1,0 +1,89 @@
+//
+//  DecryptMessageDemoView.swift
+//  NostrSDKDemo
+//
+//  Created by Fabian Lachman on 31/12/24.
+//
+
+import SwiftUI
+import NostrSDK
+
+struct DecryptMessageDemoView: View, EventCreating {
+
+    @EnvironmentObject var relayPool: RelayPool
+
+    @State private var senderPublicKey = ""
+    @State private var senderPublicKeyIsValid: Bool = false
+
+    @State private var receiverPrivateKey = ""
+    @State private var receiverPrivateKeyIsValid: Bool = false
+
+    @State private var encryptedMessage: String = ""
+    @State private var message: String = ""
+
+    var body: some View {
+        Form {
+            Text("Decrypt Demo")
+            Section("Sender") {
+                KeyInputSectionView(key: $senderPublicKey,
+                                    isValid: $senderPublicKeyIsValid,
+                                    type: .public)
+            }
+            Section("Receiver") {
+                KeyInputSectionView(key: $receiverPrivateKey,
+                                    isValid: $receiverPrivateKeyIsValid,
+                                    type: .private)
+            }
+            Section("Encrypted Message") {
+                TextField("Enter encrypted message.", text: $encryptedMessage)
+            }
+            Button("Decrypt") {
+                guard let senderPublicKey = publicKey(),
+                      let receiverPrivateKey = keypair() else {
+                    return
+                }
+                do {
+                    message = try decrypt(payload: encryptedMessage, privateKeyA: receiverPrivateKey.privateKey, publicKeyB: senderPublicKey)
+                } catch {
+                    message = ""
+                    print(error.localizedDescription)
+                }
+            }
+            .disabled(!ready())
+            
+            if message != "" {
+                Section("Decrypted Message") {
+                    TextField("Decrypted Message", text: $message)
+                }
+            }
+        }
+    }
+
+    private func keypair() -> Keypair? {
+        if receiverPrivateKey.contains("nsec") {
+            return Keypair(nsec: receiverPrivateKey)
+        } else {
+            return Keypair(hex: receiverPrivateKey)
+        }
+    }
+
+    private func publicKey() -> PublicKey? {
+        if senderPublicKey.contains("npub") {
+            return PublicKey(npub: senderPublicKey)
+        } else {
+            return PublicKey(hex: senderPublicKey)
+        }
+    }
+
+    private func ready() -> Bool {
+        !encryptedMessage.isEmpty &&
+        senderPublicKeyIsValid &&
+        receiverPrivateKeyIsValid
+    }
+}
+
+struct DecryptMessageDemoView_Previews: PreviewProvider {
+    static var previews: some View {
+        DecryptMessageDemoView()
+    }
+}

--- a/demo/NostrSDKDemo/Demo Views/EncryptMessageDemoView.swift
+++ b/demo/NostrSDKDemo/Demo Views/EncryptMessageDemoView.swift
@@ -1,0 +1,89 @@
+//
+//  EncryptMessageDemoView.swift
+//  NostrSDKDemo
+//
+//  Created by Fabian Lachman on 31/12/24.
+//
+
+import SwiftUI
+import NostrSDK
+
+struct EncryptMessageDemoView: View, EventCreating {
+
+    @EnvironmentObject var relayPool: RelayPool
+
+    @State private var recipientPublicKey = ""
+    @State private var recipientPublicKeyIsValid: Bool = false
+
+    @State private var senderPrivateKey = ""
+    @State private var senderPrivateKeyIsValid: Bool = false
+
+    @State private var message: String = ""
+    @State private var encryptedMessage: String = ""
+
+    var body: some View {
+        Form {
+            Text("Encrypt Demo")
+            Section("Recipient") {
+                KeyInputSectionView(key: $recipientPublicKey,
+                                    isValid: $recipientPublicKeyIsValid,
+                                    type: .public)
+            }
+            Section("Sender") {
+                KeyInputSectionView(key: $senderPrivateKey,
+                                    isValid: $senderPrivateKeyIsValid,
+                                    type: .private)
+            }
+            Section("Message") {
+                TextField("Enter a message.", text: $message)
+            }
+            Button("Encrypt") {
+                guard let recipientPublicKey = publicKey(),
+                      let senderKeyPair = keypair() else {
+                    return
+                }
+                do {
+                    encryptedMessage = try encrypt(plaintext: message, privateKeyA: senderKeyPair.privateKey, publicKeyB: recipientPublicKey)
+                } catch {
+                    encryptedMessage = ""
+                    print(error.localizedDescription)
+                }
+            }
+            .disabled(!ready())
+            
+            if encryptedMessage != "" {
+                Section("Encrypted Message") {
+                    TextField("Encrypted Message", text: $encryptedMessage)
+                }
+            }
+        }
+    }
+
+    private func keypair() -> Keypair? {
+        if senderPrivateKey.contains("nsec") {
+            return Keypair(nsec: senderPrivateKey)
+        } else {
+            return Keypair(hex: senderPrivateKey)
+        }
+    }
+
+    private func publicKey() -> PublicKey? {
+        if recipientPublicKey.contains("npub") {
+            return PublicKey(npub: recipientPublicKey)
+        } else {
+            return PublicKey(hex: recipientPublicKey)
+        }
+    }
+
+    private func ready() -> Bool {
+        !message.isEmpty &&
+        recipientPublicKeyIsValid &&
+        senderPrivateKeyIsValid
+    }
+}
+
+struct EncryptDecryptDemoView_Previews: PreviewProvider {
+    static var previews: some View {
+        EncryptMessageDemoView()
+    }
+}


### PR DESCRIPTION
I added an example for encrypting/decrypting with nip44 to the demo project, I was using this myself to help me understand but might be useful for others too.

I copied the style from LegacyDirectMessageDemoView but limited it to encrypt/decrypt, no publishing to relays.